### PR TITLE
Respect send_wildcard with default origins configuration

### DIFF
--- a/flask_cors.py
+++ b/flask_cors.py
@@ -85,8 +85,6 @@ def cross_origin(origins=None, methods=None, headers=None,
             and isinstance(headers, collections.Iterable)):
         headers = ', '.join(x for x in headers)
 
-    wildcard = origins == '*'
-
     if isinstance(max_age, timedelta):
         max_age = max_age.total_seconds()
 
@@ -95,6 +93,7 @@ def cross_origin(origins=None, methods=None, headers=None,
             # Determine origins when in the context of a request
             origins = _origins or current_app.config.get('CORS_ORIGINS', '*')
             origins_str = str(origins)
+            wildcard = origins_str == '*'
 
             if(not isinstance(origins, string_types)
                     and isinstance(origins, collections.Iterable)):

--- a/tests/test_w3.py
+++ b/tests/test_w3.py
@@ -34,6 +34,14 @@ class OriginsW3TestCase(FlaskCorsTestCase):
             '''
             return 'Welcome!'
 
+        @self.app.route('/default-origins')
+        @cross_origin(send_wildcard=False, always_send=False)
+        def noWildcard():
+            ''' With the default origins configuration, send_wildcard should
+                still be respected.
+            '''
+            return 'Welcome!'
+
     def test_wildcard_origin_header(self):
         ''' If there is an Origin header in the request, the
             Access-Control-Allow-Origin header should be echoed back.
@@ -55,6 +63,22 @@ class OriginsW3TestCase(FlaskCorsTestCase):
             for verb in self.iter_verbs(c):
                 result = verb('/')
                 self.assertTrue(ACL_ORIGIN not in result.headers)
+
+    def test_wildcard_default_origins(self):
+        ''' If there is an Origin header in the request, the
+            Access-Control-Allow-Origin header should be echoed back.
+        '''
+        example_origin = 'http://example.com'
+        with self.app.test_client() as c:
+            for verb in self.iter_verbs(c):
+                result = verb(
+                    '/default-origins',
+                    headers={'Origin': example_origin}
+                )
+                self.assertEqual(
+                    result.headers.get(ACL_ORIGIN),
+                    example_origin
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, if `origins` is set via an app config (e.g. `app.config['CORS_ORIGINS']`) or if the default is used, the `send_wildcard` param is not respected.

If the decorator is called without `origins`, the `send_wildcard` param should still be respected.
