### PR TITLE
Refactor and simplify tests

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -8,7 +8,7 @@
     :copyright: (c) 2014 by Cory Dolphin.
     :license: MIT, see LICENSE for more details.
 """
-
+from flask import Flask
 try:
     import unittest2 as unittest
 except ImportError:
@@ -74,7 +74,7 @@ class FlaskCorsTestCase(unittest.TestCase):
 
 class AppConfigTest(object):
     def setUp(self):
-        self.app = None
+        self.app = Flask(self.__class__.__name__)
 
     def tearDown(self):
         self.app = None

--- a/tests/test_app_extension.py
+++ b/tests/test_app_extension.py
@@ -157,8 +157,8 @@ class AppExtensionString(FlaskCorsTestCase):
 class AppExtensionError(FlaskCorsTestCase):
     def test_value_error(self):
         try:
-            self.app = Flask(__name__)
-            CORS(self.app, resources=5)
+            app = Flask(__name__)
+            CORS(app, resources=5)
             self.assertTrue(False, "Should've raised a value error")
         except ValueError:
             pass

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -38,17 +38,15 @@ class SupportsCredentialsCase(FlaskCorsTestCase):
         ''' The specified route should return the
             Access-Control-Allow-Credentials header.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_credentials')
-            header = resp.headers.get(ACL_CREDENTIALS)
-            self.assertEquals(header, 'true')
+        resp = self.get('/test_credentials')
+        header = resp.headers.get(ACL_CREDENTIALS)
+        self.assertEquals(header, 'true')
 
     def test_open_request(self):
         ''' The default behavior should be to disallow credentials.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_open')
-            self.assertTrue(ACL_CREDENTIALS not in resp.headers)
+        resp = self.get('/test_open')
+        self.assertTrue(ACL_CREDENTIALS not in resp.headers)
 
 
 class AppConfigExposeHeadersTestCase(AppConfigTest, SupportsCredentialsCase):
@@ -56,7 +54,6 @@ class AppConfigExposeHeadersTestCase(AppConfigTest, SupportsCredentialsCase):
         super(SupportsCredentialsCase, self).__init__(*args, **kwargs)
 
     def test_credentialed_request(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_SUPPORTS_CREDENTIALS'] = True
 
         @self.app.route('/test_credentials')
@@ -67,8 +64,6 @@ class AppConfigExposeHeadersTestCase(AppConfigTest, SupportsCredentialsCase):
         super(AppConfigExposeHeadersTestCase, self).test_credentialed_request()
 
     def test_open_request(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/test_open')
         @cross_origin()
         def test_open():

--- a/tests/test_expose_headers.py
+++ b/tests/test_expose_headers.py
@@ -42,34 +42,32 @@ class ExposeHeadersTestCase(FlaskCorsTestCase):
             return 'Welcome!'
 
     def test_default(self):
-        with self.app.test_client() as c:
-            resp =  c.get('/test_default')
-            self.assertTrue(resp.headers.get(ACL_EXPOSE_HEADERS) is None,
-                            "Default should have no allowed headers")
+        resp = self.get('/test_default')
+        self.assertTrue(resp.headers.get(ACL_EXPOSE_HEADERS) is None,
+                        "Default should have no allowed headers")
 
     def test_list_serialized(self):
         ''' If there is an Origin header in the request,
             the Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_list')
-            self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS), 'http://bar.com, http://foo.com')
+        resp = self.get('/test_list')
+        self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS),
+                         'http://bar.com, http://foo.com')
 
     def test_string_serialized(self):
         ''' If there is an Origin header in the request, the
             Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_string')
-            self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS), 'http://foo.com')
+        resp = self.get('/test_string')
+        self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS), 'http://foo.com')
 
     def test_set_serialized(self):
         ''' If there is an Origin header in the request, the
             Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_set')
-            self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS), 'http://bar.com, http://foo.com')
+        resp = self.get('/test_set')
+        self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS),
+                         'http://bar.com, http://foo.com')
 
 
 class AppConfigExposeHeadersTestCase(AppConfigTest, ExposeHeadersTestCase):
@@ -77,17 +75,16 @@ class AppConfigExposeHeadersTestCase(AppConfigTest, ExposeHeadersTestCase):
         super(AppConfigExposeHeadersTestCase, self).__init__(*args, **kwargs)
 
     def test_default(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/test_default')
         @cross_origin()
         def test_default():
             return 'Welcome!'
+
         super(AppConfigExposeHeadersTestCase, self).test_default()
 
     def test_list_serialized(self):
-        self.app = Flask(__name__)
-        self.app.config['CORS_EXPOSE_HEADERS'] = ["http://foo.com", "http://bar.com"]
+        self.app.config['CORS_EXPOSE_HEADERS'] = ["http://foo.com",
+                                                  "http://bar.com"]
 
         @self.app.route('/test_list')
         @cross_origin()
@@ -97,7 +94,6 @@ class AppConfigExposeHeadersTestCase(AppConfigTest, ExposeHeadersTestCase):
         super(AppConfigExposeHeadersTestCase, self).test_list_serialized()
 
     def test_string_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_EXPOSE_HEADERS'] = "http://foo.com"
 
         @self.app.route('/test_string')
@@ -108,13 +104,14 @@ class AppConfigExposeHeadersTestCase(AppConfigTest, ExposeHeadersTestCase):
         super(AppConfigExposeHeadersTestCase, self).test_string_serialized()
 
     def test_set_serialized(self):
-        self.app = Flask(__name__)
-        self.app.config['CORS_EXPOSE_HEADERS'] = set(["http://foo.com", "http://bar.com"])
+        self.app.config['CORS_EXPOSE_HEADERS'] = set(["http://foo.com",
+                                                      "http://bar.com"])
 
         @self.app.route('/test_set')
         @cross_origin()
         def test_string():
             return 'Welcome!'
+
         super(AppConfigExposeHeadersTestCase, self).test_set_serialized()
 
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -64,9 +64,8 @@ class HeadersTestCase(FlaskCorsTestCase):
         ''' If there is an Origin header in the request, the
             Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_set')
-            self.assertEqual(resp.headers.get(ACL_HEADERS), 'Bar, Foo')
+        resp = self.get('/test_set')
+        self.assertEqual(resp.headers.get(ACL_HEADERS), 'Bar, Foo')
 
 
 class AppConfigHeadersTestCase(AppConfigTest, HeadersTestCase):
@@ -74,7 +73,6 @@ class AppConfigHeadersTestCase(AppConfigTest, HeadersTestCase):
         super(AppConfigHeadersTestCase, self).__init__(*args, **kwargs)
 
     def test_list_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_HEADERS'] = ['Foo', 'Bar']
 
         @self.app.route('/test_list')
@@ -85,7 +83,6 @@ class AppConfigHeadersTestCase(AppConfigTest, HeadersTestCase):
         super(AppConfigHeadersTestCase, self).test_list_serialized()
 
     def test_string_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_HEADERS'] = 'Foo'
 
         @self.app.route('/test_string')
@@ -96,7 +93,6 @@ class AppConfigHeadersTestCase(AppConfigTest, HeadersTestCase):
         super(AppConfigHeadersTestCase, self).test_string_serialized()
 
     def test_set_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_HEADERS'] = set(["Foo", "Bar"])
 
         @self.app.route('/test_set')
@@ -106,8 +102,6 @@ class AppConfigHeadersTestCase(AppConfigTest, HeadersTestCase):
         super(AppConfigHeadersTestCase, self).test_set_serialized()
 
     def test_default(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/test_default')
         @cross_origin()
         def test_default():

--- a/tests/test_max_age.py
+++ b/tests/test_max_age.py
@@ -70,8 +70,6 @@ class AppConfigMaxAgeTestCase(AppConfigTest, MaxAgeTestCase):
         super(AppConfigMaxAgeTestCase, self).__init__(*args, **kwargs)
 
     def test_defaults(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/defaults')
         @cross_origin()
         def defaults():
@@ -80,7 +78,6 @@ class AppConfigMaxAgeTestCase(AppConfigTest, MaxAgeTestCase):
         super(AppConfigMaxAgeTestCase, self).test_defaults()
 
     def test_string(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_MAX_AGE'] = 600
 
         @self.app.route('/test_string')
@@ -91,7 +88,6 @@ class AppConfigMaxAgeTestCase(AppConfigTest, MaxAgeTestCase):
         super(AppConfigMaxAgeTestCase, self).test_string()
 
     def test_time_delta(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_MAX_AGE'] = timedelta(minutes=10)
 
         @self.app.route('/test_time_delta')
@@ -106,7 +102,6 @@ class AppConfigMaxAgeTestCase(AppConfigTest, MaxAgeTestCase):
             methods defined by the user.
         '''
         # timedelta.total_seconds is not available in older versions of Python
-        self.app = Flask(__name__)
         self.app.config['CORS_MAX_AGE'] = 600
 
         @self.app.route('/test_override')

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -43,10 +43,10 @@ class MethodsCase(FlaskCorsTestCase):
         ''' By default, Access-Control-Allow-Methods should only be returned
             if the client makes an OPTIONS request.
         '''
-        with self.app.test_client() as c:
-            self.assertFalse(ACL_METHODS in c.get('/defaults').headers)
-            self.assertFalse(ACL_METHODS in c.head('/defaults').headers)
-            self.assertTrue(ACL_METHODS in c.options('/defaults').headers)
+
+        self.assertFalse(ACL_METHODS in self.get('/defaults').headers)
+        self.assertFalse(ACL_METHODS in self.head('/defaults').headers)
+        self.assertTrue(ACL_METHODS in self.options('/defaults').headers)
 
     def test_methods_defined(self):
         ''' If the methods parameter is defined, always return the allowed
@@ -66,8 +66,6 @@ class AppConfigMethodsTestCase(AppConfigTest, MethodsCase):
         super(AppConfigMethodsTestCase, self).__init__(*args, **kwargs)
 
     def test_defaults(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/defaults')
         @cross_origin()
         def defaults():
@@ -76,7 +74,6 @@ class AppConfigMethodsTestCase(AppConfigTest, MethodsCase):
         super(AppConfigMethodsTestCase, self).test_defaults()
 
     def test_methods_defined(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_METHODS'] = ['GET']
 
         @self.app.route('/get')
@@ -87,8 +84,6 @@ class AppConfigMethodsTestCase(AppConfigTest, MethodsCase):
         super(AppConfigMethodsTestCase, self).test_methods_defined()
 
     def test_all_methods(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/all_methods', methods=ALL_METHODS)
         @cross_origin()
         def test_all_methods():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -45,17 +45,16 @@ class OptionsTestCase(FlaskCorsTestCase):
             The default behavior should automatically provide OPTIONS
             and return CORS headers.
         '''
-        with self.app.test_client() as c:
-            resp =  c.options('/test_default')
-            self.assertEqual(resp.status_code, 200)
-            self.assertTrue(ACL_ORIGIN in resp.headers)
+        resp = self.options('/test_default')
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(ACL_ORIGIN in resp.headers)
 
-            headers = {'Origin': 'http://foo.bar.com/'}
-            resp =  c.options('/test_default', headers=headers)
+        headers = {'Origin': 'http://foo.bar.com/'}
+        resp = self.options('/test_default', headers=headers)
 
-            self.assertEqual(resp.status_code, 200)
-            self.assertTrue(ACL_ORIGIN in resp.headers)
-            self.assertEqual(resp.headers[ACL_ORIGIN], '*')
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(ACL_ORIGIN in resp.headers)
+        self.assertEqual(resp.headers[ACL_ORIGIN], '*')
 
     def test_no_options_and_not_auto(self):
         '''
@@ -63,33 +62,30 @@ class OptionsTestCase(FlaskCorsTestCase):
             OPTIONS, then Flask's default handling will occur, and no CORS
             headers will be returned.
         '''
-        with self.app.test_client() as c:
-            resp =  c.options('/test_no_options_and_not_auto')
-            self.assertEqual(resp.status_code, 200)
-            self.assertFalse(ACL_ORIGIN in resp.headers)
+        resp = self.options('/test_no_options_and_not_auto')
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(ACL_ORIGIN in resp.headers)
 
-            headers = {'Origin': 'http://foo.bar.com/'}
-            resp =  c.options('/test_no_options_and_not_auto',
-                               headers=headers)
-            self.assertEqual(resp.status_code, 200)
-            self.assertFalse(ACL_ORIGIN in resp.headers)
+        headers = {'Origin': 'http://foo.bar.com/'}
+        resp = self.options('/test_no_options_and_not_auto', headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(ACL_ORIGIN in resp.headers)
 
     def test_options_and_not_auto(self):
         '''
             If OPTIONS is in methods, and automatic_options is False,
             the view function must return a response.
         '''
-        with self.app.test_client() as c:
-            resp =  c.options('/test_options_and_not_auto')
-            self.assertEqual(resp.status_code, 200)
-            self.assertTrue(ACL_ORIGIN in resp.headers)
-            self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
+        resp = self.options('/test_options_and_not_auto')
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(ACL_ORIGIN in resp.headers)
+        self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
 
-            headers = {'Origin': 'http://foo.bar.com/'}
-            resp =  c.options('/test_options_and_not_auto', headers=headers)
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.headers[ACL_ORIGIN], '*')
-            self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
+        headers = {'Origin': 'http://foo.bar.com/'}
+        resp = self.options('/test_options_and_not_auto', headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers[ACL_ORIGIN], '*')
+        self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
 
 
 class AppOptionsTestCase(AppConfigTest, OptionsTestCase):
@@ -97,8 +93,6 @@ class AppOptionsTestCase(AppConfigTest, OptionsTestCase):
         super(OptionsTestCase, self).__init__(*args, **kwargs)
 
     def test_defaults(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/test_default')
         @cross_origin()
         def test_default():
@@ -107,10 +101,13 @@ class AppOptionsTestCase(AppConfigTest, OptionsTestCase):
         super(AppOptionsTestCase, self).test_defaults()
 
     def test_no_options_and_not_auto(self):
+        @self.app.route('/test_no_options_and_not_auto')
+        @cross_origin(automatic_options=False)
+        def test_no_options_and_not_auto():
+            return 'Welcome!'
         pass
 
     def test_options_and_not_auto(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_AUTOMATIC_OPTIONS'] = False
 
         @self.app.route('/test_options_and_not_auto', methods=['OPTIONS'])

--- a/tests/test_origins.py
+++ b/tests/test_origins.py
@@ -67,29 +67,26 @@ class OriginsTestCase(FlaskCorsTestCase):
         ''' If there is an Origin header in the request, the
             Access-Control-Allow-Origin header should be echoed.
         '''
-        with self.app.test_client() as c:
-            resp = c.get('/test_list')
-            self.assertEqual(resp.headers.get(ACL_ORIGIN),
-                             'http://bar.com, http://foo.com')
+        resp = self.get('/test_list')
+        self.assertEqual(resp.headers.get(ACL_ORIGIN),
+                         'http://bar.com, http://foo.com')
 
     def test_string_serialized(self):
         ''' If there is an Origin header in the request,
             the Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp = c.get('/test_string')
-            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://foo.com')
+        resp = self.get('/test_string')
+        self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://foo.com')
 
     def test_set_serialized(self):
         ''' If there is an Origin header in the request,
             the Access-Control-Allow-Origin header should be echoed back.
         '''
-        with self.app.test_client() as c:
-            resp = c.get('/test_set')
+        resp = self.get('/test_set')
 
-            allowed = resp.headers.get(ACL_ORIGIN)
-            # Order is not garaunteed
-            self.assertEqual(allowed, 'http://bar.com, http://foo.com')
+        allowed = resp.headers.get(ACL_ORIGIN)
+        # Order is not garaunteed
+        self.assertEqual(allowed, 'http://bar.com, http://foo.com')
 
     def test_not_matching_origins(self):
         for resp in self.iter_responses('/test_list',
@@ -102,8 +99,6 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(OriginsTestCase, self).__init__(*args, **kwargs)
 
     def test_wildcard_defaults_no_origin(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/')
         @cross_origin()
         def wildcard():
@@ -112,8 +107,6 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(AppConfigOriginsTestCase, self).test_wildcard_defaults_no_origin()
 
     def test_wildcard_defaults_origin(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/')
         @cross_origin()
         def wildcard():
@@ -121,7 +114,6 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(AppConfigOriginsTestCase, self).test_wildcard_defaults_origin()
 
     def test_list_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
 
         @self.app.route('/test_list')
@@ -132,7 +124,6 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(AppConfigOriginsTestCase, self).test_list_serialized()
 
     def test_string_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_ORIGINS'] = "http://foo.com"
 
         @self.app.route('/test_string')
@@ -143,7 +134,6 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(AppConfigOriginsTestCase, self).test_string_serialized()
 
     def test_set_serialized(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_ORIGINS'] = set(["http://foo.com",
                                                "http://bar.com"])
 
@@ -155,16 +145,14 @@ class AppConfigOriginsTestCase(AppConfigTest, OriginsTestCase):
         super(AppConfigOriginsTestCase, self).test_set_serialized()
 
     def test_not_matching_origins(self):
-        pass
-        # self.app = Flask(__name__)
-        # self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
+        self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
 
-        # @self.app.route('/test_list')
-        # @cross_origin()
-        # def test_list():
-        #     return 'Welcome!'
+        @self.app.route('/test_list')
+        @cross_origin()
+        def test_list():
+            return 'Welcome!'
 
-        # super(AppConfigOriginsTestCase, self).test_not_matching_origins()
+        super(AppConfigOriginsTestCase, self).test_not_matching_origins()
 
 
 if __name__ == "__main__":

--- a/tests/test_vary_header.py
+++ b/tests/test_vary_header.py
@@ -69,12 +69,12 @@ class VaryHeaderTestCase(FlaskCorsTestCase):
             If Flask-Cors adds a Vary header and there is already a Vary
             header set, the headers should be combined and comma-separated.
         '''
-        with self.app.test_client() as c:
-            resp =  c.get('/test_existing_vary_headers')
-            self.assertEqual(
-                resp.headers.get('Vary'),
-                'Origin, Accept-Encoding'
-            )
+
+        resp = self.get('/test_existing_vary_headers')
+        self.assertEqual(
+            resp.headers.get('Vary'),
+            'Origin, Accept-Encoding'
+        )
 
 
 class AppConfigVaryHeaderTestCase(AppConfigTest,
@@ -83,8 +83,6 @@ class AppConfigVaryHeaderTestCase(AppConfigTest,
         super(AppConfigVaryHeaderTestCase, self).__init__(*args, **kwargs)
 
     def test_consistent_origin(self):
-        self.app = Flask(__name__)
-
         @self.app.route('/')
         @cross_origin()
         def wildcard():
@@ -93,7 +91,6 @@ class AppConfigVaryHeaderTestCase(AppConfigTest,
         super(AppConfigVaryHeaderTestCase, self).test_consistent_origin()
 
     def test_varying_origin(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
 
         @self.app.route('/test_vary')
@@ -104,7 +101,6 @@ class AppConfigVaryHeaderTestCase(AppConfigTest,
         super(AppConfigVaryHeaderTestCase, self).test_varying_origin()
 
     def test_consistent_origin_concat(self):
-        self.app = Flask(__name__)
         self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
 
         @self.app.route('/test_existing_vary_headers')

--- a/tests/test_w3.py
+++ b/tests/test_w3.py
@@ -50,7 +50,7 @@ class OriginsW3TestCase(FlaskCorsTestCase):
         example_origin = 'http://example.com'
         with self.app.test_client() as c:
             for verb in self.iter_verbs(c):
-                resp =  verb('/', headers={'Origin': example_origin})
+                resp = verb('/', headers={'Origin': example_origin})
                 self.assertEqual(
                     resp.headers.get(ACL_ORIGIN),
                     example_origin
@@ -62,7 +62,7 @@ class OriginsW3TestCase(FlaskCorsTestCase):
         '''
         with self.app.test_client() as c:
             for verb in self.iter_verbs(c):
-                resp =  verb('/')
+                resp = verb('/')
                 self.assertTrue(ACL_ORIGIN not in resp.headers)
 
     def test_wildcard_default_origins(self):
@@ -72,7 +72,7 @@ class OriginsW3TestCase(FlaskCorsTestCase):
         example_origin = 'http://example.com'
         with self.app.test_client() as c:
             for verb in self.iter_verbs(c):
-                resp =  verb(
+                resp = verb(
                     '/default-origins',
                     headers={'Origin': example_origin}
                 )


### PR DESCRIPTION
Reduces code repetition in testing and improves readability of failing tests (when they fail!).

Credit to http://erikzaadi.com/2012/09/13/inheritance-within-python-unit-tests/ for his great tip on inheritance in Python unit tests. 
