### PR TITLE
MANIFEST.in: Distribute the tests/ directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include README.rst
 include LICENSE
 recursive-include docs *
 recursive-include examples *.py
+recursive-include tests *.py
 prune docs/_build


### PR DESCRIPTION
Avoid:

  $ python setup.py test
  ...
  warning: no files found matching '*.py' under directory 'tests'
  ...

---

  Ran 0 tests in 0.003s

  OK

by packaging the referenced files.
