### PR TITLE
Use headers.get instead of indexing in test cases

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -70,6 +70,12 @@ class FlaskCorsTestCase(unittest.TestCase):
     def delete(self, *args, **kwargs):
         return self._request('delete', *args, **kwargs)
 
+    def assertHasACLOrigin(self, resp, origin=None):
+        if origin is None:
+            self.assertTrue(ACL_ORIGIN in resp.headers)
+        else:
+            self.assertTrue(resp.headers.get(ACL_ORIGIN) == origin)
+
 
 class AppConfigTest(object):
     def setUp(self):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -54,7 +54,7 @@ class MethodsCase(FlaskCorsTestCase):
         '''
         for resp in self.iter_responses('/get'):
             self.assertTrue(ACL_METHODS in resp.headers)
-            self.assertTrue('GET' in resp.headers[ACL_METHODS])
+            self.assertTrue('GET' in resp.headers.get(ACL_METHODS))
 
     def test_all_methods(self):
         for resp in self.iter_responses('/all_methods', verbs=ALL_METHODS):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -54,7 +54,7 @@ class OptionsTestCase(FlaskCorsTestCase):
 
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(ACL_ORIGIN in resp.headers)
-        self.assertEqual(resp.headers[ACL_ORIGIN], '*')
+        self.assertEqual(resp.headers.get(ACL_ORIGIN), '*')
 
     def test_no_options_and_not_auto(self):
         '''
@@ -84,7 +84,7 @@ class OptionsTestCase(FlaskCorsTestCase):
         headers = {'Origin': 'http://foo.bar.com/'}
         resp = self.options('/test_options_and_not_auto', headers=headers)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.headers[ACL_ORIGIN], '*')
+        self.assertEqual(resp.headers.get(ACL_ORIGIN), '*')
         self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
 
 

--- a/tests/test_origins.py
+++ b/tests/test_origins.py
@@ -114,7 +114,7 @@ class OriginsTestCase(FlaskCorsTestCase):
             domain = "http://%s.example.com" % sub
             for resp in self.iter_responses('/test_subdomain_regex',
                                             headers={'origin': domain}):
-                self.assertEqual(domain, resp.headers[ACL_ORIGIN])
+                self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
     def test_regex_list(self):
         for parent in 'example.com', 'otherexample.com':
@@ -122,7 +122,7 @@ class OriginsTestCase(FlaskCorsTestCase):
                 domain = "http://%s.%s.com" % (sub, parent)
                 for resp in self.iter_responses('/test_regex_list',
                                                 headers={'origin': domain}):
-                    self.assertEqual(domain, resp.headers[ACL_ORIGIN])
+                    self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
     def test_regex_mixed_list(self):
         '''
@@ -143,10 +143,10 @@ class OriginsTestCase(FlaskCorsTestCase):
             domain = "http://%s.otherexample.com" % sub
             for resp in self.iter_responses('/test_regex_mixed_list',
                                             headers={'origin': domain}):
-                self.assertEqual(domain, resp.headers[ACL_ORIGIN])
+                self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
         self.assertEquals("http://example.com",
-                          self.get('/test_regex_mixed_list').headers[ACL_ORIGIN]
+                          self.get('/test_regex_mixed_list').headers.get(ACL_ORIGIN)
                           )
 
 


### PR DESCRIPTION
Stops Errors counting as Failures.
