### PR TITLE
tests/base_test.py: Use __name__ for Flask's import_name

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -79,7 +79,7 @@ class FlaskCorsTestCase(unittest.TestCase):
 
 class AppConfigTest(object):
     def setUp(self):
-        self.app = Flask(self.__class__.__name__)
+        self.app = Flask(import_name=__name__)
 
     def tearDown(self):
         self.app = None


### PR DESCRIPTION
Avoid several test failures like:

```
======================================================================
ERROR: test_credentialed_request (tests.test_credentials.AppConfigExposeHeadersTestCase)
AppConfigExposeHeadersTestCase.test_credentialed_request
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/.../tests/base_test.py", line 82, in setUp
    self.app = Flask(self.__class__.__name__)
  File "/usr/lib64/python3.4/site-packages/flask/app.py", line 319, in __init__
    template_folder=template_folder)
  File "/usr/lib64/python3.4/site-packages/flask/helpers.py", line 741, in __init__
    self.root_path = get_root_path(self.import_name)
  File "/usr/lib64/python3.4/site-packages/flask/helpers.py", line 631, in get_root_path
    loader = pkgutil.get_loader(import_name)
  File "/usr/lib64/python3.4/pkgutil.py", line 469, in get_loader
    return find_loader(fullname)
  File "/usr/lib64/python3.4/pkgutil.py", line 490, in find_loader
    return spec.loader
AttributeError: 'NoneType' object has no attribute 'loader'
```

on Python 3.4 [1](https://github.com/mitsuhiko/flask/issues/1011).  The solution is to use an importable name [2](http://flask.pocoo.org/docs/0.10/api/#flask.Flask):

> About the First Parameter
> 
> The idea of the first parameter is to give Flask an idea what
> belongs to your application. This name is used to find resources on
> the file system, can be used by extensions to improve debugging
> information and a lot more.
> 
> So it’s important what you provide there. If you are using a single
> module, **name** is always the correct value. If you however are
> using a package, it’s usually recommended to hardcode the name of
> your package there.

Previously we were using the class name (not the module name), but you
can't use that to import anything ;).
