### PR TITLE
Decouple the determination of CORS headers 

### DIFF
--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -46,15 +46,15 @@ class MethodsCase(FlaskCorsTestCase):
 
         self.assertFalse(ACL_METHODS in self.get('/defaults').headers)
         self.assertFalse(ACL_METHODS in self.head('/defaults').headers)
-        self.assertTrue(ACL_METHODS in self.options('/defaults').headers)
+        self.assertEqual(', '.join(sorted(ALL_METHODS)),
+            self.options('/defaults').headers.get(ACL_METHODS))
 
     def test_methods_defined(self):
-        ''' If the methods parameter is defined, always return the allowed
+        ''' If the methods parameter is defined, it should override the default
             methods defined by the user.
         '''
-        for resp in self.iter_responses('/get'):
-            self.assertTrue(ACL_METHODS in resp.headers)
-            self.assertTrue('GET' in resp.headers.get(ACL_METHODS))
+        self.assertEqual('GET' , self.options('/get').headers.get(ACL_METHODS))
+        self.assertFalse(ACL_METHODS in self.get('/get').headers)
 
     def test_all_methods(self):
         for resp in self.iter_responses('/all_methods', verbs=ALL_METHODS):


### PR DESCRIPTION
from the Flask request and response to make future testing simpler.

This will allow me to simplify the tests to have less flask-testing related cruft, and more explicitly unit test the pieces I am interested in. E.G. determining the options under different conditions, and then actually testing the headers returned as a result of different options and request conditions.

Also, sneakily changes behavior if methods is set due to refactor. Implementation now should be w3c compatible. 
