### PR TITLE
Add RST checking to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,32 @@
+sudo: false
 language: python
 python:
-- '2.6'
-- '2.7'
-- '3.3'
-- '3.4'
-- pypy
-- pypy3
+  - '2.6'
+  - '2.7'
+  - '3.3'
+  - '3.4'
+  - '3.5'
+  - pypy
+  - pypy3
+
 env:
 - FLASK=0.10.1
 - FLASK=0.10
-- FLASK=0.9
-matrix:
-  allow_failures:
-  - python: '3.3'
-    env: FLASK=0.9
-  - python: 'pypy3'
-    env: FLASK=0.9
-  - python: '3.4'
-    env: FLASK=0.9
+
 install:
-- pip install pep8 coveralls six
-- pip install -U "pip>=1.4" "setuptools>=0.9" "wheel>=0.21"
-- pip install flask==$FLASK
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools # We want to use setup.py check
+  - pip install -U pep8 coveralls six docutils pygments flask==$FLASK
+
 script:
-- coverage erase
-- nosetests --with-coverage --cover-package=flask_cors
-- python setup.py clean build install
+  - coverage erase
+  - nosetests --with-coverage --cover-package=flask_cors
+  - python setup.py clean build install
+
 after_success:
-- pep8 flask_cors.py
-- coveralls
+  - pep8 flask_cors.py
+  - coveralls
+
 deploy:
   provider: pypi
   user: CoryDolphin

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ For a full list of options, please see the full
 `documentation <http://flask-cors.corydolphin.com/en/latest/>`__
 
 Troubleshooting
------
+---------------
 
 If things aren't working as you expect, enable logging to help understand
 what is going on under the hood, and why.

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@
 """
 
 from setuptools import setup
-
 from os.path import join, dirname
+
 with open(join(dirname(__file__), 'flask_cors/version.py'), 'r') as f:
     exec(f.read())
 
@@ -45,9 +45,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',


### PR DESCRIPTION
1. Adds verification of RST to CI because Pypi will show raw text if there are ANY warnings. Lame
2. Updates test matrix to drop Python 3.3. and 3.4 in favor of 3.5. Similarly drops Flask 0.9
3. Updates Readme to add some underlines. Damnit RST. 