### PR TITLE
Delete complicated inheritance-based App-configuration tests

### DIFF
--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -87,22 +87,3 @@ class FlaskCorsTestCase(unittest.TestCase):
             self.assertTrue(ACL_ORIGIN in resp.headers)
         else:
             self.assertTrue(resp.headers.get(ACL_ORIGIN) == origin)
-
-
-class AppConfigTest(object):
-    def setUp(self):
-        self.app = Flask(import_name=__name__)
-
-    def tearDown(self):
-        self.app = None
-
-    def add_route(self, path):
-
-        # Flask checks the name of the function to ensure that iew mappings
-        # do not collide. We work around it by generating a new function name
-        # for the path
-        def function_to_rename():
-            return 'STUBBED: %s' % path
-        function_to_rename.__name__ = 'func_%s' % path
-
-        self.app.route(path)(function_to_rename)

--- a/tests/decorator/test_credentials.py
+++ b/tests/decorator/test_credentials.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 
 from flask_cors import *
@@ -59,28 +59,6 @@ class SupportsCredentialsCase(FlaskCorsTestCase):
 
         resp = self.get('/test_credentials_unsupported')
         self.assertFalse(ACL_CREDENTIALS in resp.headers)
-
-
-class AppConfigExposeHeadersTestCase(AppConfigTest, SupportsCredentialsCase):
-    def __init__(self, *args, **kwargs):
-        super(AppConfigExposeHeadersTestCase, self).__init__(*args, **kwargs)
-
-    def test_credentials_supported(self):
-        self.app.config['CORS_SUPPORTS_CREDENTIALS'] = True
-
-        @self.app.route('/test_credentials_supported')
-        @cross_origin()
-        def test_credentials_supported():
-            return 'Credentials!'
-
-        super(AppConfigExposeHeadersTestCase, self).test_credentials_supported()
-
-    def test_open_request(self):
-        @self.app.route('/test_default')
-        @cross_origin()
-        def test_default():
-            return 'Open!'
-        super(AppConfigExposeHeadersTestCase, self).test_default()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/decorator/test_expose_headers.py
+++ b/tests/decorator/test_expose_headers.py
@@ -6,7 +6,7 @@
     Flask-Cors tests module
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 
 from flask_cors import *
@@ -39,31 +39,6 @@ class ExposeHeadersTestCase(FlaskCorsTestCase):
         for resp in self.iter_responses('/test_override', origin='www.example.com'):
             self.assertEqual(resp.headers.get(ACL_EXPOSE_HEADERS),
                              'X-Another-Custom-Header, X-My-Custom-Header')
-
-
-class AppConfigExposeHeadersTestCase(AppConfigTest, ExposeHeadersTestCase):
-    def __init__(self, *args, **kwargs):
-        super(AppConfigExposeHeadersTestCase, self).__init__(*args, **kwargs)
-
-    def test_default(self):
-        @self.app.route('/test_default')
-        @cross_origin()
-        def test_default():
-            return 'Welcome!'
-
-        super(AppConfigExposeHeadersTestCase, self).test_default()
-
-    def test_override(self):
-        self.app.config['CORS_EXPOSE_HEADERS'] = ["X-My-Custom-Header",
-                                                  "X-Another-Custom-Header"]
-
-        @self.app.route('/test_override')
-        @cross_origin()
-        def test_override():
-            return 'Welcome!'
-
-        super(AppConfigExposeHeadersTestCase, self).test_override()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/decorator/test_max_age.py
+++ b/tests/decorator/test_max_age.py
@@ -10,7 +10,7 @@
 """
 from datetime import timedelta
 import sys
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 
 from flask_cors import *
@@ -59,54 +59,6 @@ class MaxAgeTestCase(FlaskCorsTestCase):
 
         resp = self.preflight('/test_time_delta', origin='www.example.com')
         self.assertEqual(resp.headers.get(ACL_MAX_AGE), '600')
-
-
-class AppConfigMaxAgeTestCase(AppConfigTest, MaxAgeTestCase):
-    def __init__(self, *args, **kwargs):
-        super(AppConfigMaxAgeTestCase, self).__init__(*args, **kwargs)
-
-    def test_defaults(self):
-        @self.app.route('/defaults')
-        @cross_origin()
-        def defaults():
-            return 'Should only return headers on OPTIONS'
-
-        super(AppConfigMaxAgeTestCase, self).test_defaults()
-
-    def test_string(self):
-        self.app.config['CORS_MAX_AGE'] = 600
-
-        @self.app.route('/test_string')
-        @cross_origin()
-        def test_string():
-            return 'Open!'
-
-        super(AppConfigMaxAgeTestCase, self).test_string()
-
-    def test_time_delta(self):
-        self.app.config['CORS_MAX_AGE'] = timedelta(minutes=10)
-
-        @self.app.route('/test_time_delta')
-        @cross_origin()
-        def test_time_delta():
-            return 'Open!'
-
-        super(AppConfigMaxAgeTestCase, self).test_time_delta()
-
-    def test_override(self):
-        ''' If the methods parameter is defined, always return the allowed
-            methods defined by the user.
-        '''
-        # timedelta.total_seconds is not available in older versions of Python
-        self.app.config['CORS_MAX_AGE'] = 600
-
-        @self.app.route('/test_override')
-        @cross_origin(max_age=900)
-        def test_override():
-            return 'Welcome!'
-
-        resp = self.preflight('/test_override', origin='www.example.com')
-        self.assertEqual(resp.headers.get(ACL_MAX_AGE), '900')
 
 
 if __name__ == "__main__":

--- a/tests/decorator/test_methods.py
+++ b/tests/decorator/test_methods.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 
 from flask_cors import *
@@ -56,29 +56,6 @@ class MethodsCase(FlaskCorsTestCase):
 
         res = self.get('/test_methods_defined', origin='www.example.com')
         self.assertFalse(ACL_METHODS in res.headers)
-
-
-class AppConfigMethodsTestCase(AppConfigTest, MethodsCase):
-    def __init__(self, *args, **kwargs):
-        super(AppConfigMethodsTestCase, self).__init__(*args, **kwargs)
-
-    def test_defaults(self):
-        @self.app.route('/defaults')
-        @cross_origin()
-        def defaults():
-            return ''
-
-        super(AppConfigMethodsTestCase, self).test_defaults()
-
-    def test_methods_defined(self):
-        self.app.config['CORS_METHODS'] = ['POST']
-
-        @self.app.route('/test_methods_defined')
-        @cross_origin()
-        def defaults():
-            return ''
-        super(AppConfigMethodsTestCase, self).test_methods_defined()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/decorator/test_options.py
+++ b/tests/decorator/test_options.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 
 from flask_cors import *
@@ -76,36 +76,6 @@ class OptionsTestCase(FlaskCorsTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(ACL_ORIGIN in resp.headers)
         self.assertEqual(resp.data.decode("utf-8"), u"Welcome!")
-
-
-class AppOptionsTestCase(AppConfigTest, OptionsTestCase):
-    def __init__(self, *args, **kwargs):
-        super(AppOptionsTestCase, self).__init__(*args, **kwargs)
-
-    def test_defaults(self):
-        @self.app.route('/test_default')
-        @cross_origin()
-        def test_default():
-            return 'Welcome!'
-
-        super(AppOptionsTestCase, self).test_defaults()
-
-    def test_no_options_and_not_auto(self):
-        @self.app.route('/test_no_options_and_not_auto')
-        @cross_origin(automatic_options=False)
-        def test_no_options_and_not_auto():
-            return 'Welcome!'
-        super(AppOptionsTestCase, self).test_no_options_and_not_auto()
-
-    def test_options_and_not_auto(self):
-        self.app.config['CORS_AUTOMATIC_OPTIONS'] = False
-
-        @self.app.route('/test_options_and_not_auto', methods=['OPTIONS'])
-        @cross_origin()
-        def test_options_and_not_auto():
-            return 'Welcome!'
-        super(AppOptionsTestCase, self).test_options_and_not_auto()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/decorator/test_origins.py
+++ b/tests/decorator/test_origins.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask
 import re
 from flask_cors import *

--- a/tests/decorator/test_vary_header.py
+++ b/tests/decorator/test_vary_header.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask, Response
 
 from flask_cors import *
@@ -82,52 +82,6 @@ class VaryHeaderTestCase(FlaskCorsTestCase):
         resp = self.get('/test_existing_vary_headers', origin="http://foo.com")
         self.assertEqual(set(resp.headers.getlist('Vary')),
                          set(['Origin', 'Accept-Encoding']))
-
-
-class AppConfigVaryHeaderTestCase(AppConfigTest,
-                                  VaryHeaderTestCase):
-    def __init__(self, *args, **kwargs):
-        super(AppConfigVaryHeaderTestCase, self).__init__(*args, **kwargs)
-
-
-    def test_default(self):
-        @self.app.route('/')
-        @cross_origin()
-        def test_default():
-            return 'Welcome!'
-
-        super(AppConfigVaryHeaderTestCase, self).test_default()
-
-
-    def test_consistent_origin(self):
-        @self.app.route('/test_consistent_origin')
-        @cross_origin(origins='http://foo.com')
-        def test_consistent_origin():
-            return 'Welcome!'
-
-        super(AppConfigVaryHeaderTestCase, self).test_consistent_origin()
-
-    def test_varying_origin(self):
-        self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
-
-        @self.app.route('/test_vary')
-        @cross_origin()
-        def test_vary():
-            return 'Welcome!'
-
-        super(AppConfigVaryHeaderTestCase, self).test_varying_origin()
-
-    def test_consistent_origin_concat(self):
-        self.app.config['CORS_ORIGINS'] = ["http://foo.com", "http://bar.com"]
-
-        @self.app.route('/test_existing_vary_headers')
-        @cross_origin(origin='http://foo.com')
-        def test_existing_vary_headers():
-            return Response('', status=200,
-                            headers={'Vary': 'Accept-Encoding'})
-
-        super(AppConfigVaryHeaderTestCase, self).test_consistent_origin_concat()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -9,14 +9,15 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from ..base_test import FlaskCorsTestCase, AppConfigTest
+from ..base_test import FlaskCorsTestCase
 from flask import Flask, jsonify
 
 from flask_cors import *
 from flask_cors.core import *
 
+letters = 'abcdefghijklmnopqrstuvwxyz'  # string.letters is not PY3 compatible
 
-class AppExtensionRegexp(AppConfigTest):
+class AppExtensionRegexp(FlaskCorsTestCase):
     def setUp(self):
         self.app = Flask(__name__)
         CORS(self.app, resources={

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -62,12 +62,11 @@ class AppExtensionRegexp(FlaskCorsTestCase):
             return 'Welcome!'
 
     def test_defaults_no_origin(self):
-        ''' If there is no Origin header in the request, the
-            Access-Control-Allow-Origin header should not be included,
-            according to the w3 spec.
+        ''' If there is no Origin header in the request,
+            by default the '*' should be sent
         '''
         for resp in self.iter_responses('/'):
-            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), '*')
 
     def test_defaults_with_origin(self):
         ''' If there is an Origin header in the request, the


### PR DESCRIPTION
These are more complication than they are work.

At some point I thought inheritance-based tests were cool. I don't like these tests, as they are overly verbose in accomplishing something which is
1. not that important (they only differ in how they read config information, which is actually unit-testable via serialize_options)
2. Complicated. Multiple inheritance?! ICK. Debugging a test failure is difficult. I think longer term it makes sense to parameterize tests to test the different calling and configuration options. 