### PR TITLE
Match exactly Access-Control-Allow-Headers

### DIFF
--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -160,7 +160,7 @@ def get_allow_headers(options, acl_request_headers):
 
         # any header that matches in the allow_headers
         matching_headers = filter(
-            lambda h: try_match_any(h, options.get('allow_headers')),
+            lambda h: try_match_any(h, options.get('allow_headers'), True),
             request_headers
         )
 
@@ -210,7 +210,7 @@ def get_cors_headers(options, request_headers, request_method, response_headers)
         if headers[ACL_ORIGIN] == '*':
             pass
         elif (len(options.get('origins')) > 1 or
-              len(origins_to_set) > 1 or 
+              len(origins_to_set) > 1 or
               any(map(probably_regex, options.get('origins')))):
             headers.add('Vary', 'Origin')
 
@@ -257,17 +257,17 @@ def re_fix(reg):
     return r'.*' if reg == r'*' else reg
 
 
-def try_match_any(inst, patterns):
-    return any(try_match(inst, pattern) for pattern in patterns)
+def try_match_any(inst, patterns, exact_match=False):
+    return any(try_match(inst, pattern, exact_match) for pattern in patterns)
 
 
-def try_match(request_origin, pattern):
+def try_match(request_origin, pattern, exact_match=False):
     """Safely attempts to match a pattern or string to a request origin."""
     try:
         if isinstance(pattern, RegexObject):
             return re.match(pattern, request_origin)
         else:
-            return re.match(pattern, request_origin, flags=re.IGNORECASE)
+            return re.match("^" + pattern + "$" if exact_match else pattern, request_origin, flags=re.IGNORECASE)
     except:
         return request_origin == pattern
 


### PR DESCRIPTION
Currently, if we define Access-Control-Allow-Headers for *X-Test* custom header, *X-Test***foo** will be allowed too, because pattern doesn't compared for an exact match.

This patch makes pattern for Access-Control-Allow-Headers an exact match.