### PR TITLE
Remove suggestion to use flask.ext.cors, favor flask_cors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,11 @@ Install the extension with using pip, or easy\_install.
 Usage
 -----
 
-This package exposes a Flask extension which by default enables CORS support on all routes, for all origins and methods. It allows parameterization of all CORS headers on a per-resource level. The package also contains a decorator, for those who prefer this approach. 
+This package exposes a Flask extension which by default enables CORS support on all routes, for all origins and methods. It allows parameterization of all CORS headers on a per-resource level. The package also contains a decorator, for those who prefer this approach.
 
 Simple Usage
 ~~~~~~~~~~~~
-  
+
 In the simplest case, initialize the Flask-Cors extension with default
 arguments in order to allow CORS for all domains on all routes. See the
 full list of options in the `documentation <http://flask-cors.corydolphin.com/en/latest/api.html#extension>`__.
@@ -41,7 +41,7 @@ full list of options in the `documentation <http://flask-cors.corydolphin.com/en
 
 
     from flask import Flask
-    from flask.ext.cors import CORS, cross_origin
+    from flask_cors import CORS, cross_origin
 
     app = Flask(__name__)
     CORS(app)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,7 +37,7 @@ cross origins, simply set the `supports_credentials` option to `True`. E.G.
 
 
     from flask import Flask, session
-    from flask.ext.cors import CORS
+    from flask_cors import CORS
 
     app = Flask(__name__)
     CORS(app, supports_credentials=True)

--- a/examples/app_based_example.py
+++ b/examples/app_based_example.py
@@ -10,14 +10,14 @@ to add cross origin support to your flask app!
 from flask import Flask, jsonify
 import logging
 try:
-    from flask.ext.cors import CORS  # The typical way to import flask-cors
+    from flask_cors import CORS  # The typical way to import flask-cors
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.sys.path.insert(0, parentdir)
 
-    from flask.ext.cors import CORS
+    from flask_cors import CORS
 
 
 app = Flask('FlaskCorsAppBasedExample')

--- a/examples/blueprints_based_example.py
+++ b/examples/blueprints_based_example.py
@@ -10,14 +10,14 @@ to add cross origin support to your flask app!
 from flask import Flask, jsonify, Blueprint
 import logging
 try:
-    from flask.ext.cors import CORS  # The typical way to import flask-cors
+    from flask_cors import CORS  # The typical way to import flask-cors
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.sys.path.insert(0, parentdir)
 
-    from flask.ext.cors import CORS
+    from flask_cors import CORS
 
 
 api_v1 = Blueprint('API_v1', __name__)

--- a/examples/view_based_example.py
+++ b/examples/view_based_example.py
@@ -11,14 +11,14 @@ from flask import Flask, jsonify
 import logging
 try:
     # The typical way to import flask-cors
-    from flask.ext.cors import cross_origin
+    from flask_cors import cross_origin
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.sys.path.insert(0, parentdir)
 
-    from flask.ext.cors import cross_origin
+    from flask_cors import cross_origin
 
 
 app = Flask('FlaskCorsViewBasedExample')

--- a/tests/decorator/__init__.py
+++ b/tests/decorator/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    Tests particular to flask.ext.cors.cross_origin
+    Tests particular to flask_cors.cross_origin
     ~~~~
     Flask-CORS is a simple extension to Flask allowing you to support cross
     origin resource sharing (CORS) using a simple decorator.

--- a/tests/decorator/test_w3.py
+++ b/tests/decorator/test_w3.py
@@ -11,15 +11,8 @@
 
 from ..base_test import FlaskCorsTestCase
 from flask import Flask
-
-try:
-    # this is how you would normally import
-    from flask.ext.cors import *
-    from flask.ext.cors.core import *
-except:
-    # support local usage without installed package
-    from flask_cors import *
-    from flask_cors.core import *
+from flask_cors import *
+from flask_cors.core import *
 
 
 class OriginsW3TestCase(FlaskCorsTestCase):

--- a/tests/extension/__init__.py
+++ b/tests/extension/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    Tests particular to flask.ext.cors.CORS
+    Tests particular to flask_cors.CORS
     ~~~~
     Flask-CORS is a simple extension to Flask allowing you to support cross
     origin resource sharing (CORS) using a simple decorator.


### PR DESCRIPTION
http://flask.pocoo.org/docs/0.11/extensiondev/
> As of Flask 0.11, most Flask extensions have transitioned to the new naming schema. The flask.ext.foo compatibility alias is still in Flask 0.11 but is now deprecated – you should use flask_foo.