### PR TITLE
Universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ deploy:
   user: CoryDolphin
   password:
     secure: c/z1OYmniNlJ7F7G+TipOlJfVLCEz0F09JCJJ4+TPB/DTxajxarMEygX/LrvBOLvbe1EvAKO9p/SOagAul00YXU/rb2i1k1tJnKF2A6KKSLOsZbTcGWNcInOaLKql4Cv8Ts1cOfMiTVHBQLR+1FCw+IuZ44N+KhF0tsFOejEmRc=
+  distributions: "sdist bdist_wheel"
   on:
     tags: true
     repo: corydolphin/flask-cors

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = true


### PR DESCRIPTION
Right now, there is only a `py2` wheel being released. This PR will cause `bdist_wheel` to build a universal `py2.py3` wheel instead. It also tells the Travis release task to upload the wheel to PyPI in addition to the `sdist` [which is the only one uploaded by default](https://docs.travis-ci.com/user/deployment/pypi#Uploading-different-distributions)