### PR TITLE
Returns the original app when initializing CORS

### DIFF
--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -127,6 +127,7 @@ class CORS(object):
         self._options = kwargs
         if app is not None:
             self.init_app(app, **kwargs)
+        return app
 
     def init_app(self, app, **kwargs):
         # The resources and options may be specified in the App Config, the CORS constructor


### PR DESCRIPTION
Helps make it more consistent with other Flask extensions.

https://github.com/corydolphin/flask-cors/issues/169 