### PR TITLE
docs: Fix simple typo, garaunteed -> guaranteed

### DIFF
--- a/tests/decorator/test_origins.py
+++ b/tests/decorator/test_origins.py
@@ -140,7 +140,7 @@ class OriginsTestCase(FlaskCorsTestCase):
         resp = self.get('/test_set', origin='http://bar.com')
 
         allowed = resp.headers.get(ACL_ORIGIN)
-        # Order is not garaunteed
+        # Order is not guaranteed
         self.assertEqual(allowed, 'http://bar.com')
 
     def test_not_matching_origins(self):
@@ -180,7 +180,7 @@ class OriginsTestCase(FlaskCorsTestCase):
             or '?') will be skipped.
 
             Thus, the list of returned Access-Control-Allow-Origin header
-            is garaunteed to be 'null', the origin or "*", as per the w3
+            is guaranteed to be 'null', the origin or "*", as per the w3
             http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
 
         '''

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -109,7 +109,7 @@ class AppExtensionRegexp(FlaskCorsTestCase):
         resp = self.get('/test_set', origin='http://bar.com')
 
         allowed = resp.headers.get(ACL_ORIGIN)
-        # Order is not garaunteed
+        # Order is not guaranteed
         self.assertEqual(allowed, 'http://bar.com')
 
     def test_not_matching_origins(self):
@@ -152,7 +152,7 @@ class AppExtensionRegexp(FlaskCorsTestCase):
             or '?') will be skipped.
 
             Thus, the list of returned Access-Control-Allow-Origin header
-            is garaunteed to be 'null', the origin or "*", as per the w3
+            is guaranteed to be 'null', the origin or "*", as per the w3
             http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
 
         '''


### PR DESCRIPTION
There is a small typo in tests/decorator/test_origins.py, tests/extension/test_app_extension.py.

Should read `guaranteed` rather than `garaunteed`.

