### PR TITLE
some trivial fixes to remove pytest DeprecationWarnings

### DIFF
--- a/tests/decorator/test_credentials.py
+++ b/tests/decorator/test_credentials.py
@@ -40,7 +40,7 @@ class SupportsCredentialsCase(FlaskCorsTestCase):
             Access-Control-Allow-Credentials header.
         '''
         resp = self.get('/test_credentials_supported', origin='www.example.com')
-        self.assertEquals(resp.headers.get(ACL_CREDENTIALS), 'true')
+        self.assertEqual(resp.headers.get(ACL_CREDENTIALS), 'true')
 
     def test_default(self):
         ''' The default behavior should be to disallow credentials.

--- a/tests/decorator/test_origins.py
+++ b/tests/decorator/test_origins.py
@@ -190,7 +190,7 @@ class OriginsTestCase(FlaskCorsTestCase):
                                             origin=domain):
                 self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
-        self.assertEquals("http://example.com",
+        self.assertEqual("http://example.com",
             self.get('/test_regex_mixed_list', origin='http://example.com').headers.get(ACL_ORIGIN))
 
     def test_multiple_protocols(self):

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -39,8 +39,8 @@ class AppExtensionRegexp(FlaskCorsTestCase):
             r'/test_send_wildcard_with_origin' : {
                 'send_wildcard':True
             },
-            re.compile('/test_compiled_subdomain_\w*'): {
-                'origins': re.compile("http://example\d+.com")
+            re.compile(r'/test_compiled_subdomain_\w*'): {
+                'origins': re.compile(r"http://example\d+.com")
             },
             r'/test_defaults':{}
         })
@@ -162,7 +162,7 @@ class AppExtensionRegexp(FlaskCorsTestCase):
                                             origin=domain):
                 self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))
 
-        self.assertEquals("http://example.com",
+        self.assertEqual("http://example.com",
             self.get('/test_regex_mixed_list', origin='http://example.com').headers.get(ACL_ORIGIN))
 
 


### PR DESCRIPTION
Just fixed some trivial things in the test suite to remove pytest's DeprecationWarnings. 

The test suite still reports the same amount of passed (79) and skipped (1) tests in the same amount of time, but no more warnings.