### PR TITLE
Added power support for the travis.yml file with ppc64le.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ matrix:
     - python: 3.4
     - env:
         - DEPEENDENCIES="flask==1.1"
-
-# Disable version  pypy for ppc64le
-jobs:
-  exclude:
    - arch: ppc64le
      python: pypy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ matrix:
     - env:
         - DEPEENDENCIES="flask==1.1"
 
+# Disable version  pypy for ppc64le
+jobs:
+  exclude:
+   - arch: ppc64le
+     python: pypy
+
 env:
 - DEPEENDENCIES="flask==0.10.1 werkzeug==0.16.1" # pin werkzeug for Flask 10, 10.1 since Flask does not pin it itself.
 - DEPEENDENCIES="flask==0.10 werkzeug==0.16.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: false
 cache:
 - pip
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - '2.7'
   - '3.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ python:
 matrix:
   exclude:
     - python: 3.4
+    - arch: ppc64le
+      python: pypy
     - env:
         - DEPEENDENCIES="flask==1.1"
-   - arch: ppc64le
-     python: pypy
 
 env:
 - DEPEENDENCIES="flask==0.10.1 werkzeug==0.16.1" # pin werkzeug for Flask 10, 10.1 since Flask does not pin it itself.


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.

excluded job pypy for ppc64le