### PR TITLE
Enable flask-cors to work well with CDNs and caches

### DIFF
--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -208,15 +208,9 @@ def get_cors_headers(options, request_headers, request_method):
 
     # http://www.w3.org/TR/cors/#resource-implementation
     if options.get('vary_header'):
-        # Only set header if the origin returned will vary dynamically,
-        # i.e. if we are not returning an asterisk, and there are multiple
-        # origins that can be matched.
-        if headers[ACL_ORIGIN] == '*':
-            pass
-        elif (len(options.get('origins')) > 1 or
-              len(origins_to_set) > 1 or
-              any(map(probably_regex, options.get('origins')))):
-            headers.add('Vary', 'Origin')
+        # Always set a vary header, so that intermediate caches know
+        # that there might be varying versions of this resource.
+        headers.add('Vary', 'Origin')
 
     return MultiDict((k, v) for k, v in headers.items() if v)
 


### PR DESCRIPTION
At present, the vary header is ONLY set if an inbound request has an appropriate 'origin' value.  This isn't compatible with using flask-cors with endpoints that have positive cache-headers.

An example scenario is:

 - User 1 requests endpoint without CORS.
 - Response is sent with 1hr cache header, and doesn't include a vary header
 - User 2 requests endpoint and requires CORS
 - Cache responds with cached response to user 1, which fails CORS checks.

This change ensures that if the vary_header flag is set, then it'll always send the header, so that flask-cors can dependably be used with caching.