### PR TITLE
Include examples to specify that schema and port must be included in …

### DIFF
--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -61,7 +61,11 @@ class CORS(object):
     :param origins:
         The origin, or list of origins to allow requests from.
         The origin(s) may be regular expressions, case-sensitive strings,
-        or else an asterisk
+        or else an asterisk.
+
+        :note: origins must include the schema and the port (if not port 80),
+        e.g.,
+        `CORS(app, origins=["http://localhost:8000", "https://example.com"])`.
 
         Default : '*'
     :type origins: list, string or regex


### PR DESCRIPTION
…origins documentation.

Thanks for building/maintaining flask-cors! 

I had a little trouble getting the `origins` parameter to work until I found #212. This PR provides documentation about the schema and port requirements.

Please let me know if any changes/suggestions!