### PR TITLE
Use allowed methods from view function

### DIFF
--- a/flask_cors/decorator.py
+++ b/flask_cors/decorator.py
@@ -124,6 +124,11 @@ def cross_origin(*args, **kwargs):
 
             if options.get('automatic_options') and request.method == 'OPTIONS':
                 resp = current_app.make_default_options_response()
+                # if decorator does not have methods, then use the allowed methods
+                # from the view function. view function methods are preferred to
+                # decorator but not to app level options.
+                if 'methods' not in _options and resp.headers.get('allow'):
+                    options['methods'] = resp.headers.get('allow')
             else:
                 resp = make_response(f(*args, **kwargs))
 

--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -184,6 +184,11 @@ def make_after_request_function(resources):
         normalized_path = unquote_plus(request.path)
         for res_regex, res_options in resources:
             if try_match(normalized_path, res_regex):
+                # if we reach here, the decorator has not evaluated the request
+                # so use the allowed methods from the view function because methods
+                # from view function are to be preferred to app level methods
+                if resp.headers is not None and resp.headers.get('allow'):
+                    res_options['methods'] = resp.headers.get('allow')
                 LOG.debug("Request to '%s' matches CORS resource '%s'. Using options: %s",
                       request.path, get_regexp_pattern(res_regex), res_options)
                 set_cors_headers(resp, res_options)

--- a/tests/decorator/test_methods.py
+++ b/tests/decorator/test_methods.py
@@ -30,6 +30,16 @@ class MethodsCase(FlaskCorsTestCase):
         def test_get():
             return 'Only allow POST'
 
+        @self.app.route('/test_methods_view', methods=['PATCH'])
+        @cross_origin()
+        def test_methods_view():
+            return 'Only allow PATCH'
+
+        @self.app.route('/test_methods_view_and_defined', methods=['POST', 'DELETE'])
+        @cross_origin(methods=['DELETE'])
+        def test_methods_view_and_defined():
+            return 'Only allow POST and DELETE'
+
     def test_defaults(self):
         ''' Access-Control-Allow-Methods headers should only be returned
             if the client makes an OPTIONS request.
@@ -38,8 +48,7 @@ class MethodsCase(FlaskCorsTestCase):
         self.assertFalse(ACL_METHODS in self.get('/defaults', origin='www.example.com').headers)
         self.assertFalse(ACL_METHODS in self.head('/defaults', origin='www.example.com').headers)
         res = self.preflight('/defaults', 'POST', origin='www.example.com')
-        for method in ALL_METHODS:
-            self.assertTrue(method in res.headers.get(ACL_METHODS))
+        self.assertIsNone(res.headers.get(ACL_METHODS))
 
     def test_methods_defined(self):
         ''' If the methods parameter is defined, it should override the default
@@ -55,6 +64,39 @@ class MethodsCase(FlaskCorsTestCase):
         self.assertFalse(ACL_METHODS in res.headers)
 
         res = self.get('/test_methods_defined', origin='www.example.com')
+        self.assertFalse(ACL_METHODS in res.headers)
+
+    def test_methods_view(self):
+        ''' If the methods parameter is defined in view function, it should override the default
+            methods defined by the user.
+        '''
+        self.assertFalse(ACL_METHODS in self.get('/test_methods_view').headers)
+        self.assertFalse(ACL_METHODS in self.head('/test_methods_view').headers)
+
+        res = self.preflight('/test_methods_view', 'PATCH', origin='www.example.com')
+        self.assertTrue('PATCH' in res.headers.get(ACL_METHODS))
+
+        res = self.preflight('/test_methods_view', 'POST', origin='www.example.com')
+        self.assertFalse(ACL_METHODS in res.headers)
+
+        res = self.get('/test_methods_view', origin='www.example.com')
+        self.assertFalse(ACL_METHODS in res.headers)
+
+    def test_methods_view_and_defined(self):
+        ''' If the methods parameter is defined in cross_origin decorator and view
+         function, the decorator methods should be used.
+        '''
+        self.assertFalse(ACL_METHODS in self.get('/test_methods_view_and_defined').headers)
+        self.assertFalse(ACL_METHODS in self.head('/test_methods_view_and_defined').headers)
+
+        res = self.preflight('/test_methods_view_and_defined', 'DELETE', origin='www.example.com')
+        self.assertTrue('DELETE' in res.headers.get(ACL_METHODS))
+        self.assertTrue('POST' not in res.headers.get(ACL_METHODS))
+
+        res = self.preflight('/test_methods_view_and_defined', 'POST', origin='www.example.com')
+        self.assertFalse(ACL_METHODS in res.headers)
+
+        res = self.get('/test_methods_view_and_defined', origin='www.example.com')
         self.assertFalse(ACL_METHODS in res.headers)
 
 if __name__ == "__main__":

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -378,5 +378,28 @@ class AppExtensionBadRegexp(FlaskCorsTestCase):
             self.assertEqual(resp.status_code, 200)
 
 
+class AppExtensionPreflight(FlaskCorsTestCase):
+    def test_preflight(self):
+        ''' Ensure that view function methods override app level defaults '''
+        self.app = Flask(__name__)
+        CORS(self.app)
+
+        @self.app.route('/')
+        def index():
+            return 'Welcome'
+
+        @self.app.route('/test', methods=['POST'])
+        def index2():
+            return 'Welcome 2'
+
+        res = self.preflight('/', 'GET', origin='www.example.com')
+        self.assertTrue('POST' not in res.headers.get(ACL_METHODS))
+        self.assertTrue('GET' in res.headers.get(ACL_METHODS))
+
+        res = self.preflight('/test', 'POST', origin='www.example.com')
+        self.assertTrue('POST' in res.headers.get(ACL_METHODS))
+        self.assertTrue('GET' not in res.headers.get(ACL_METHODS))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allowed methods are used in the following hierarchy:
1) methods parameter of cross_origin decorator
2) methods parameter of view function route
3) resource or app level configuration

I tried to implement this in `set_cors_headers` but couldn't because it is called from both decorator and extension. In the case of the decorator, we do not want to use the methods from view function if the decorator had those specified but in case of extension we want to use it always.
https://github.com/corydolphin/flask-cors/blob/24c45cef84a160207057c7c0735fc5fb08143420/flask_cors/core.py#L224

Fixes #228 