### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,7 +21,7 @@ The configuration options recognised by Flask-CORS are:
 
 CORS_ALLOW_HEADERS (:py:class:`~typing.List` or :py:class:`str`)
    Headers to accept from the client.
-   Headers in the :http:header:`Access-Control-Request-Headers` request header (usually part of the preflight OPTIONS request) maching headers in this list will be included in the :http:header:`Access-Control-Allow-Headers` response header.
+   Headers in the :http:header:`Access-Control-Request-Headers` request header (usually part of the preflight OPTIONS request) matching headers in this list will be included in the :http:header:`Access-Control-Allow-Headers` response header.
 
 CORS_ALWAYS_SEND (:py:class:`bool`)
    Usually, if a request doesn't include an :http:header:`Origin` header, the client did not request CORS.

--- a/tests/decorator/test_exception_interception.py
+++ b/tests/decorator/test_exception_interception.py
@@ -117,7 +117,7 @@ class ExceptionInterceptionDefaultTestCase(FlaskCorsTestCase):
         '''
             If a 500 handler is setup by the user, responses should have
             CORS matching rules applied, regardless of whether or not
-            intercept_exceptions is enbaled.
+            intercept_exceptions is enabled.
         '''
         return_string = "Simple error handler"
 
@@ -168,7 +168,7 @@ class NoExceptionInterceptionTestCase(ExceptionInterceptionDefaultTestCase):
         '''
             If a 500 handler is setup by the user, responses should have
             CORS matching rules applied, regardless of whether or not
-            intercept_exceptions is enbaled.
+            intercept_exceptions is enabled.
         '''
         return_string = "Simple error handler"
 


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- tests/decorator/test_exception_interception.py

Fixes:
- Should read `enabled` rather than `enbaled`.
- Should read `matching` rather than `maching`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md