### PR TITLE
[Feature Suggestion] Configurable response status code to invalid CORS request

### DIFF
--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -62,7 +62,8 @@ DEFAULT_OPTIONS = dict(origins='*',
                        vary_header=True,
                        resources=r'/*',
                        intercept_exceptions=True,
-                       always_send=True)
+                       always_send=True,
+                       invalid_cors_status_code=200)
 
 
 def parse_resources(resources):

--- a/flask_cors/decorator.py
+++ b/flask_cors/decorator.py
@@ -100,6 +100,24 @@ def cross_origin(*args, **kwargs):
         Default : True
     :type automatic_options: bool
 
+    :param invalid_cors_status_code:
+        Response status code when CORS request is invalid.
+
+        According to the CORS spec documentation from
+        `WHATWG <setuptools pep8 six coverage docutils pygments packaging>`_,
+        any response status code can be returned for CORS request.
+        Sometimes, for security, you wish flask_cors just returns HTTP
+        reponse without processing the HTTP request.
+
+        If `invalid_cors_status_code` set to client error response, from 400
+        to 499, flask_cors just returns HTTP response with that status code
+        and process nothing to the HTTP request.
+        Or else, flask_cors returns HTTP response with status code 200 and
+        response content to the HTTP request.
+
+        Default : 200
+    :type vary_header: int
+
     """
     _options = kwargs
 

--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -129,6 +129,25 @@ class CORS(object):
 
         Default : True
     :type vary_header: bool
+
+    :param invalid_cors_status_code:
+        Response status code when CORS request is invalid.
+
+        According to the CORS spec documentation from
+        `WHATWG <setuptools pep8 six coverage docutils pygments packaging>`_,
+        any response status code can be returned for CORS request.
+        Sometimes, for security, you wish flask_cors just returns HTTP
+        reponse without processing the HTTP request.
+
+        If `invalid_cors_status_code` set to client error response, from 400
+        to 499, flask_cors just returns HTTP response with that status code
+        and process nothing to the HTTP request.
+        Or else, flask_cors returns HTTP response with status code 200 and
+        response content to the HTTP request.
+
+        Default : 200
+    :type vary_header: int
+
     """
 
     def __init__(self, app=None, **kwargs):

--- a/tests/decorator/test_invalid_cors_response_status_code.py
+++ b/tests/decorator/test_invalid_cors_response_status_code.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+    test
+    ~~~~
+    Flask-CORS is a simple extension to Flask allowing you to support cross
+    origin resource sharing (CORS) using a simple decorator.
+
+    :copyright: (c) 2016 by Cory Dolphin.
+    :license: MIT, see LICENSE for more details.
+"""
+
+import unittest
+from ..base_test import FlaskCorsTestCase
+from flask import Flask
+from flask_cors import *
+from flask_cors.core import *
+
+
+class DecoratorInvalidCorsResponseStatusCode(FlaskCorsTestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+        @self.app.route('/with_no_options')
+        @cross_origin(origins=['http://valid.com'])
+        def with_no_options():
+            return 'NO OPTIONS!'
+
+        @self.app.route('/with_client_error_status')
+        @cross_origin(
+            origins=['http://valid.com'],
+            invalid_cors_status_code=403
+        )
+        def with_client_error_status():
+            return 'WITH 403!'
+
+        @self.app.route('/with_non_client_error_response')
+        @cross_origin(
+            origins=['http://valid.com'],
+            invalid_cors_status_code=304
+        )
+        def with_non_client_error_response():
+            return 'WITH 304!'
+
+    def test_with_no_options(self):
+        ''' If no `invalid_cors_status_code` options set,
+            response code OK(200) will be returned
+            when invalid CORS request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_no_options',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'NO OPTIONS!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for index, resp in enumerate(self.iter_responses(
+                '/with_no_options',
+                verbs=['get', 'head', 'options'],
+                origin='http://invalid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            expected = u'NO OPTIONS!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+    def test_with_client_error_status(self):
+        ''' If `invalid_cors_status_code` options set as 403,
+            which is Clinet Error Status Code, response code
+            FORBIDDEN(403) will be returned when invalid CORS
+            request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_client_error_status',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'WITH 403!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for resp in self.iter_responses('/with_client_error_status', origin='http://invalid.com'):
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            self.assertEqual(resp.data.decode('utf-8'), u'')
+
+    def test_with_non_client_error_status(self):
+        ''' If `invalid_cors_status_code` options set as 200,
+            which is not Clinet Error Status Code, response
+            code OK(200) will be returned when invalid CORS
+            request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_non_client_error_response',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'WITH 304!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for resp in self.iter_responses('/with_non_client_error_response', origin='http://invalid.com'):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            self.assertEqual(resp.data.decode('utf-8'), u'')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -378,5 +378,102 @@ class AppExtensionBadRegexp(FlaskCorsTestCase):
             self.assertEqual(resp.status_code, 200)
 
 
+class AppExtensionInvalidCorsResponseStatusCode(FlaskCorsTestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        CORS(self.app, resources={
+            r'/with_no_options': {
+                'origins': {'http://valid.com'}
+            },
+            r'/with_client_error_status': {
+                'origins': {'http://valid.com'},
+                'invalid_cors_status_code': 403
+            },
+            r'/with_non_client_error_response': {
+                'origins': {'http://valid.com'},
+                'invalid_cors_status_code': 304
+            },
+        })
+
+        @self.app.route('/with_no_options')
+        def with_no_options():
+            return 'NO OPTIONS!'
+
+        @self.app.route('/with_client_error_status')
+        def with_client_error_status():
+            return 'WITH 403!'
+
+        @self.app.route('/with_non_client_error_response')
+        def with_non_client_error_response():
+            return 'WITH 304!'
+
+    def test_with_no_options(self):
+        ''' If no `invalid_cors_status_code` options set,
+            response code OK(200) will be returned
+            when invalid CORS request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_no_options',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'NO OPTIONS!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for index, resp in enumerate(self.iter_responses(
+                '/with_no_options',
+                verbs=['get', 'head', 'options'],
+                origin='http://invalid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            expected = u'NO OPTIONS!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+    def test_with_client_error_status(self):
+        ''' If `invalid_cors_status_code` options set as 403,
+            which is Clinet Error Status Code, response code
+            FORBIDDEN(403) will be returned when invalid CORS
+            request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_client_error_status',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'WITH 403!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for resp in self.iter_responses('/with_client_error_status', origin='http://invalid.com'):
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            self.assertEqual(resp.data.decode('utf-8'), u'')
+
+    def test_with_non_client_error_status(self):
+        ''' If `invalid_cors_status_code` options set as 200,
+            which is not Clinet Error Status Code, response
+            code OK(200) will be returned when invalid CORS
+            request.
+        '''
+        for index, resp in enumerate(self.iter_responses(
+                '/with_non_client_error_response',
+                verbs=['get', 'head', 'options'],
+                origin='http://valid.com'
+            )):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), 'http://valid.com')
+            expected = u'WITH 304!' if index == 0 else u''
+            self.assertEqual(resp.data.decode('utf-8'), expected)
+
+        for resp in self.iter_responses('/with_non_client_error_response', origin='http://invalid.com'):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), None)
+            self.assertEqual(resp.data.decode('utf-8'), u'')
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Configurable CORS response code when CORS request is invalid

Thank you for taking look at this PR!

## In summary

- Add CORS option `invalid_cors_status_code`
  - Configures CORS response code when `Access-Control-Allowed-Origin` is not in response header
  - For backward compatibility, default value is `200` same as current behaviour.

**The default behaviour is SAME as current behaviour.**

## Details

### Background

According to [CORS document from WHATWG](https://fetch.spec.whatwg.org/#http-responses), CORS protocol can take any response code to CORS request as long as response header contains CORS headers like `Access-Control-Allow-Origin`.
It does not specify response code and response body.

> A successful HTTP response, i.e., one where the server developer intends to share it, to a [CORS request](https://fetch.spec.whatwg.org/#cors-request) can use any [status](https://fetch.spec.whatwg.org/#concept-status), as long as it includes the [headers](https://fetch.spec.whatwg.org/#concept-header) stated above with [values](https://fetch.spec.whatwg.org/#concept-header-value) matching up with the request.
>
> A successful HTTP response to a [CORS-preflight request](https://fetch.spec.whatwg.org/#cors-preflight-request) is similar, except it is restricted to an [ok status](https://fetch.spec.whatwg.org/#ok-status), e.g., 200 or 204.


But, there might be some wishes like 'Not to return response to invalid CORS request' for security'. From the WHATWG doc,
> Any other kind of HTTP response is not successful and will either end up not being shared or fail the [CORS-preflight request](https://fetch.spec.whatwg.org/#cors-preflight-request). Be aware that any work the server performs might nonetheless leak through side channels, such as timing. If server developers wish to denote this explicitly, the 403 [status](https://fetch.spec.whatwg.org/#concept-status) can be used, coupled with omitting the relevant [headers](https://fetch.spec.whatwg.org/#concept-header).

So I implemented the feature.

### Feature

Add `invalid_cors_status_code` argument for CORS configuration to `flask_cors.CORS` and `flask_cors.cross_origin`.

Note:
1. Now, Flask-Cors responses to the CORS request with status `200` and response body.
To maintain the backward compatibility, the argument default value is `200` and does not change response body when `invalid_cors_status_code` is not passed or passed `200`.

2. Personally, response code to the invalid CORS request should be `403` like Spring Security or `401` if it should be authenticated.
At least Client Error Response Code in [Mozilla HTPP response code doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) should be returned, which is from `400` to `499`.
So, by setting variable `INVALID_CORS_STATUS_MIN = 400` and `INVALID_CORS_STATUS_MAX = 499` in `flask_cors/core.py`, this feature filters `invalid_cors_status_code`.
If other value like `302` is set to `invalid_cors_status_code`, this sets response status `200`(set in `INVALID_CORS_DEFAULT_STATUS`) and response body `''`(set in `INVALID_CORS_RESPONSE_DATA`).


Checked with `nosetests --with-coverage --cover-package=flask_cors`.

Thank you so much!