### PR TITLE
Update version support in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[bdist_wheel]
-universal = true
+[options]
+python_requires = >= 3.8


### PR DESCRIPTION
This pull request updates the configuration to correctly reflect supported Python versions. This includes removing the that was still building wheels for Python 2 even though Python 2 support has been dropped and adding a Python version requirement that matches the metadata described in `setup.py`. This should resolve #339.