### PR TITLE
Update extension.py to escape request.path before logging it

### DIFF
--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -194,7 +194,7 @@ def make_after_request_function(resources):
         for res_regex, res_options in resources:
             if try_match(normalized_path, res_regex):
                 LOG.debug("Request to '%s' matches CORS resource '%s'. Using options: %s",
-                      request.path, get_regexp_pattern(res_regex), res_options)
+                      repr(request.path), get_regexp_pattern(res_regex), res_options)
                 set_cors_headers(resp, res_options)
                 break
         else:


### PR DESCRIPTION
Hi @corydolphin 

In this PR I've used Python's `repr` method to escape special characters and print them as ordinary characters as a bugfix for [CVE-2024-1681](https://github.com/advisories/GHSA-84pr-m4jr-85g5) - [https://nvd.nist.gov/vuln/detail/CVE-2024-1681](https://nvd.nist.gov/vuln/detail/CVE-2024-1681).

This should resolve #349.