### PR TITLE
Re-freeze docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,27 +1,34 @@
-alabaster==0.7.13 ; python_version >= "3.8"
-babel==2.14.0 ; python_version >= "3.8"
-certifi==2024.2.2 ; python_version >= "3.8"
-charset-normalizer==3.3.2 ; python_version >= "3.8"
-colorama==0.4.6 ; python_version >= "3.8" and sys_platform == "win32"
-docutils==0.20.1 ; python_version >= "3.8"
-idna==3.6 ; python_version >= "3.8"
-imagesize==1.4.1 ; python_version >= "3.8"
-importlib-metadata==7.0.1 ; python_version < "3.10" and python_version >= "3.8"
-jinja2==3.1.3 ; python_version >= "3.8"
-markupsafe==2.1.5 ; python_version >= "3.8"
-packaging==23.2 ; python_version >= "3.8"
-pygments==2.17.2 ; python_version >= "3.8"
-pytz==2024.1 ; python_version < "3.9" and python_version >= "3.8"
-requests==2.31.0 ; python_version >= "3.8"
-snowballstemmer==2.2.0 ; python_version >= "3.8"
-sphinx==7.1.2 ; python_version >= "3.8"
-sphinx-rtd-theme==2.0.0 ; python_version >= "3.8"
-sphinxcontrib-applehelp==1.0.4 ; python_version >= "3.8"
-sphinxcontrib-devhelp==1.0.2 ; python_version >= "3.8"
-sphinxcontrib-htmlhelp==2.0.1 ; python_version >= "3.8"
-sphinxcontrib-httpdomain==1.8.1 ; python_version >= "3.8"
-sphinxcontrib-jsmath==1.0.1 ; python_version >= "3.8"
-sphinxcontrib-qthelp==1.0.3 ; python_version >= "3.8"
-sphinxcontrib-serializinghtml==1.1.5 ; python_version >= "3.8"
-urllib3==2.2.1 ; python_version >= "3.8"
-zipp==3.17.0 ; python_version < "3.10" and python_version >= "3.8"
+alabaster==0.7.16
+argcomplete==3.2.3
+Babel==2.15.0
+blinker==1.8.1
+certifi==2024.2.2
+charset-normalizer==3.3.2
+click==8.1.7
+docutils==0.20.1
+Flask==3.0.3
+idna==3.7
+imagesize==1.4.1
+itsdangerous==2.2.0
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+packaging==24.0
+pipx==1.5.0
+platformdirs==4.2.0
+Pygments==2.18.0
+requests==2.31.0
+six==1.16.0
+snowballstemmer==2.2.0
+Sphinx==7.3.7
+sphinx-rtd-theme==2.0.0
+sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-httpdomain==1.8.1
+sphinxcontrib-jquery==4.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-serializinghtml==1.1.10
+urllib3==2.2.1
+userpath==1.9.2
+Werkzeug==3.0.3


### PR DESCRIPTION
Read the Docs builds are still failing, but due to missing dependencies like Flask.

I created this PR with the following steps, iterating each time by trying to run `make html` locally.

```bash
# Set up an independent virtual environment
cd docs/
python -m venv .venv
source .venv/bin/activate

pip install sphinx
make html

# Needs Flask
pip install flask
make html

# Needs sphinxcontrib.httpdomain
pip install sphinxcontrib.httpdomain
make html

# Needs sphinx_rtd_theme
pip install sphinx_rtd_theme
make html

# Many warnings printed regarding RST syntax, directives, etc
# but there were no missing modules, so this was sufficient.
pip freeze > requirements.txt
```

As noted in the comment above, there are still many warnings about RST syntax and directives when building the docs, but at least the missing modules were accounted for. The `.readthedocs.yaml` file has `fail_on_warning` disabled so this should at least allow the builds to succeed.

Closes #347, too.