### PR TITLE
[Docs] Fix links to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Simple Usage
 ~~~~~~~~~~~~
 
 In the simplest case, initialize the Flask-Cors extension with default arguments in order to allow CORS for all domains on all routes.
-See the full list of options in the `documentation <https://flask-cors.corydolphin.com/en/latest/api.html#extension>`__.
+See the full list of options in the `documentation <https://flask-cors.readthedocs.io/en/latest/api.html#extension>`__.
 
 .. code:: python
 
@@ -51,7 +51,7 @@ Resource specific CORS
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Alternatively, you can specify CORS options on a resource and origin level of granularity by passing a dictionary as the `resources` option, mapping paths to a set of options.
-See the full list of options in the `documentation <https://flask-cors.corydolphin.com/en/latest/api.html#extension>`__.
+See the full list of options in the `documentation <https://flask-cors.readthedocs.io/en/latest/api.html#extension>`__.
 
 .. code:: python
 
@@ -67,7 +67,7 @@ Route specific CORS via decorator
 
 This extension also exposes a simple decorator to decorate flask routes with.
 Simply add ``@cross_origin()`` below a call to Flask's ``@app.route(..)`` to allow CORS on a given route.
-See the full list of options in the `decorator documentation <https://flask-cors.corydolphin.com/en/latest/api.html#decorator>`__.
+See the full list of options in the `decorator documentation <https://flask-cors.readthedocs.io/en/latest/api.html#decorator>`__.
 
 .. code:: python
 
@@ -79,7 +79,7 @@ See the full list of options in the `decorator documentation <https://flask-cors
 Documentation
 -------------
 
-For a full list of options, please see the full `documentation <https://flask-cors.corydolphin.com/en/latest/api.html>`__
+For a full list of options, please see the full `documentation <https://flask-cors.readthedocs.io/en/latest/api.html>`__
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
Closes #360.

For consistency, [the docs url should also change](https://github.com/corydolphin/flask-cors/issues/360#issuecomment-2327515097) in the repository description.