### PR TITLE
Fix packaging: missing source files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-py-modules = ["flask_cors"]
+packages = ["flask_cors"]
 # This is a workaround for https://github.com/astral-sh/uv/issues/9513
 license-files = []
 


### PR DESCRIPTION
This is a pretty strong reason why we should move the actual contents into `src` in the future. The only reason this passed CI was because of the relative imports succeeding when tests ran.