### PR TITLE
Fix README file extension in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "flask-cors"
 version = "0.0.1"
 description = "A Flask extension simplifying CORS support"
 authors = [{ name = "Cory Dolphin", email = "corydolphin@gmail.com" }]
-readme = "README.md"
+readme = "README.rst"
 keywords = ['python']
 requires-python = ">=3.9,<4.0"
 classifiers = [


### PR DESCRIPTION
This might be the reason PyPI doesn't show the README.