### PR TITLE
[CVE-2024-6839] Sort Paths by Regex Specificity

### DIFF
--- a/tests/core/helper_tests.py
+++ b/tests/core/helper_tests.py
@@ -78,7 +78,7 @@ class InternalsTestCase(unittest.TestCase):
 
         self.assertEqual(
             [r[0] for r in resources],
-            [re.compile(r'/api/v1/.*'), '/foo', re.compile(r'/.*')]
+            ['/foo', re.compile(r'/api/v1/.*'), re.compile(r'/.*')]
         )
 
     def test_probably_regex(self):


### PR DESCRIPTION
## [CVE-2024-6839] Sort Paths by Regex Specificity

Before this change, the library matched CORS resource paths by sorting regex patterns based on string length. This flawed logic allowed less specific but longer regexes (e.g., /.*) to take precedence over more specific paths (e.g., /api/v1/secure), potentially applying overly permissive CORS rules to sensitive endpoints. This could lead to unauthorized cross-origin access, data leaks, and misuse of protected APIs.

The fix updates the resource matching logic in parse_resources to:
- Prioritize exact string paths (most specific).
- Among regex patterns, prefer deeper paths (with more /) and longer regexes, assuming they are more specific.
- Ensure the most specific match is used first, reducing risk of applying a permissive policy to a sensitive route.

Addresses 1/3 issues raised in https://github.com/corydolphin/flask-cors/issues/384