### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 description = "A Flask extension simplifying CORS support"
 authors = [{ name = "Cory Dolphin", email = "corydolphin@gmail.com" }]
 readme = "README.rst"
+license = "MIT"
 keywords = ['python']
 requires-python = ">=3.9,<4.0"
 classifiers = [


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project