### PR TITLE
Explicitly document proper regex requirements for origins

### DIFF
--- a/flask_cors/decorator.py
+++ b/flask_cors/decorator.py
@@ -22,6 +22,11 @@ def cross_origin(*args, **kwargs):
         The origin(s) may be regular expressions, case-sensitive strings,
         or else an asterisk
 
+        ..  note:
+        
+            When using regexes, ensure that you assert the position at the
+            end of the string
+
         Default : '*'
     :type origins: list, string or regex
 

--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -56,9 +56,14 @@ class CORS:
 
         ..  note::
 
-            origins must include the schema and the port (if not port 80),
+            origins must include the scheme and the port (if different than default),
             e.g.,
             `CORS(app, origins=["http://localhost:8000", "https://example.com"])`.
+
+            when using regexes, escape needed characters and assert end of string
+            e.g.,
+            `CORS(app, origins=[r"https://.*\\.example\\.com\\Z"])
+            And not `r"https://.*\\.example\\.com"` which would allow `https://a.example.com.attacker.com`
 
         Default : '*'
     :type origins: list, string or regex

--- a/tests/extension/test_app_extension.py
+++ b/tests/extension/test_app_extension.py
@@ -28,19 +28,19 @@ class AppExtensionRegexp(FlaskCorsTestCase):
                 'origins': {"http://foo.com", "http://bar.com"}
             },
             r'/test_subdomain_regex': {
-                'origins': r"http?://\w*\.?example\.com:?\d*/?.*"
+                'origins': r"https?://\w*\.?example\.com:?\d*\Z"
             },
             r'/test_regex_list': {
-                'origins': [r".*.example.com", r".*.otherexample.com"]
+                'origins': [r"http://.*\.example\.com\Z", r"http://.*\.otherexample.com\Z"]
             },
             r'/test_regex_mixed_list': {
-                'origins': ["http://example.com", r".*.otherexample.com"]
+                'origins': ["http://example.com", r"http://.*\.otherexample\.com\Z"]
             },
             r'/test_send_wildcard_with_origin' : {
                 'send_wildcard':True
             },
             re.compile(r'/test_compiled_subdomain_\w*'): {
-                'origins': re.compile(r"http://example\d+.com")
+                'origins': re.compile(r"http://example\d+.com\Z")
             },
             r'/test_defaults':{}
         })
@@ -136,7 +136,7 @@ class AppExtensionRegexp(FlaskCorsTestCase):
     def test_regex_list(self):
         for parent in 'example.com', 'otherexample.com':
             for sub in letters:
-                domain = "http://{}.{}.com".format(sub, parent)
+                domain = "http://{}.{}".format(sub, parent)
                 for resp in self.iter_responses('/test_regex_list',
                                                 headers={'origin': domain}):
                     self.assertEqual(domain, resp.headers.get(ACL_ORIGIN))


### PR DESCRIPTION
Unlike https://pypi.org/project/django-cors-headers/ which documents and gives proper examples of valid regexes for origins, this project does not give any example leaving it to the user to know how to write good regexes.

The regexes used in the unit tests actually allow to circumvent the allowed domains.

This PR aims to improve the documentation and fix the tests.