### PR TITLE
Support callable origins for dynamic validation

### DIFF
--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -113,6 +113,18 @@ def get_regexp_pattern(regexp):
 
 def get_cors_origins(options, request_origin):
     origins = options.get("origins")
+
+    # If origins is a callable, invoke it to get the actual origins.
+    # The callable receives the request origin and should return:
+    # - A string (single origin or "*")
+    # - A list/set of allowed origins
+    # - None to deny the request
+    if callable(origins):
+        origins = origins(request_origin)
+        if origins is None:
+            return None
+        origins = sanitize_regex_param(origins)
+
     wildcard = r".*" in origins
 
     # If the Origin header is not present terminate this set of steps.
@@ -223,7 +235,8 @@ def get_cors_headers(options, request_headers, request_method):
         # origins that can be matched.
         if headers[ACL_ORIGIN] == "*":
             pass
-        elif (
+        # If origins is callable, always vary since origins are dynamic
+        elif callable(options.get("origins")) or (
             len(options.get("origins")) > 1
             or len(origins_to_set) > 1
             or any(map(probably_regex, options.get("origins")))
@@ -284,6 +297,7 @@ def re_fix(reg):
 def try_match_any_pattern(inst, patterns, caseSensitive=True):
     return any(try_match_pattern(inst, pattern, caseSensitive) for pattern in patterns)
 
+
 def try_match_pattern(value, pattern, caseSensitive=True):
     """
     Safely attempts to match a pattern or string to a value. This
@@ -306,6 +320,7 @@ def try_match_pattern(value, pattern, caseSensitive=True):
         return v == p if caseSensitive else v.casefold() == p.casefold()
     except Exception:
         return value == pattern
+
 
 def get_cors_options(appInstance, *dicts):
     """
@@ -378,12 +393,24 @@ def serialize_options(opts):
             LOG.warning("Unknown option passed to Flask-CORS: %s", key)
 
     # Ensure origins is a list of allowed origins with at least one entry.
-    options["origins"] = sanitize_regex_param(options.get("origins"))
+    # If origins is a callable, preserve it for runtime evaluation.
+    origins = options.get("origins")
+    if callable(origins):
+        options["origins"] = origins
+    else:
+        options["origins"] = sanitize_regex_param(origins)
+
     options["allow_headers"] = sanitize_regex_param(options.get("allow_headers"))
 
     # This is expressly forbidden by the spec. Raise a value error so people
     # don't get burned in production.
-    if r".*" in options["origins"] and options["supports_credentials"] and options["send_wildcard"]:
+    # Skip this check for callable origins since we can't know the values until runtime.
+    if (
+        not callable(options["origins"])
+        and r".*" in options["origins"]
+        and options["supports_credentials"]
+        and options["send_wildcard"]
+    ):
         raise ValueError(
             "Cannot use supports_credentials in conjunction with"
             "an origin string of '*'. See: "

--- a/tests/decorator/test_callable_origins.py
+++ b/tests/decorator/test_callable_origins.py
@@ -1,0 +1,117 @@
+"""
+test_callable_origins
+~~~~~~~~~~~~~~~~~~~~~
+Tests for callable origins support in Flask-CORS.
+
+:copyright: (c) 2024 by Cory Dolphin.
+:license: MIT, see LICENSE for more details.
+"""
+
+from flask import Flask
+
+from flask_cors import cross_origin
+from flask_cors.core import ACL_ORIGIN
+
+from ..base_test import FlaskCorsTestCase
+
+
+class CallableOriginsTestCase(FlaskCorsTestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+        # Simple callable that returns a static list
+        def static_origins(request_origin):
+            return ["http://foo.com", "http://bar.com"]
+
+        # Callable that validates against a whitelist
+        def whitelist_origins(request_origin):
+            allowed = {"http://foo.com", "http://bar.com"}
+            if request_origin in allowed:
+                return request_origin
+            return None
+
+        # Callable that returns wildcard
+        def wildcard_origins(request_origin):
+            return "*"
+
+        @self.app.route("/test_callable_static")
+        @cross_origin(origins=static_origins)
+        def test_callable_static():
+            return "Welcome!"
+
+        @self.app.route("/test_callable_whitelist")
+        @cross_origin(origins=whitelist_origins)
+        def test_callable_whitelist():
+            return "Welcome!"
+
+        @self.app.route("/test_callable_wildcard")
+        @cross_origin(origins=wildcard_origins, send_wildcard=True)
+        def test_callable_wildcard():
+            return "Welcome!"
+
+    def test_callable_static_with_matching_origin(self):
+        """Callable returning static list should allow matching origins."""
+        for resp in self.iter_responses("/test_callable_static", origin="http://foo.com"):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), "http://foo.com")
+
+    def test_callable_static_with_non_matching_origin(self):
+        """Callable returning static list should reject non-matching origins."""
+        for resp in self.iter_responses("/test_callable_static", origin="http://evil.com"):
+            self.assertEqual(resp.status_code, 200)
+            self.assertIsNone(resp.headers.get(ACL_ORIGIN))
+
+    def test_callable_whitelist_with_matching_origin(self):
+        """Callable that validates against whitelist should allow matching origins."""
+        for resp in self.iter_responses("/test_callable_whitelist", origin="http://bar.com"):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), "http://bar.com")
+
+    def test_callable_whitelist_with_non_matching_origin(self):
+        """Callable returning None should reject the origin."""
+        for resp in self.iter_responses("/test_callable_whitelist", origin="http://evil.com"):
+            self.assertEqual(resp.status_code, 200)
+            self.assertIsNone(resp.headers.get(ACL_ORIGIN))
+
+    def test_callable_wildcard(self):
+        """Callable returning wildcard should send '*'."""
+        for resp in self.iter_responses("/test_callable_wildcard", origin="http://any.com"):
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), "*")
+
+    def test_callable_vary_header(self):
+        """Callable origins should always include Vary header."""
+        for resp in self.iter_responses("/test_callable_whitelist", origin="http://foo.com"):
+            self.assertIn("Origin", resp.headers.get("Vary", ""))
+
+
+class CallableOriginsExtensionTestCase(FlaskCorsTestCase):
+    """Test callable origins with the CORS extension (app-wide)."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+
+        def dynamic_origins(request_origin):
+            # Simulate database lookup
+            allowed = {"http://app1.example.com", "http://app2.example.com"}
+            if request_origin in allowed:
+                return request_origin
+            return None
+
+        from flask_cors import CORS
+
+        CORS(self.app, origins=dynamic_origins)
+
+        @self.app.route("/")
+        def index():
+            return "Hello!"
+
+    def test_extension_callable_allowed(self):
+        """Extension with callable origins should allow matching origins."""
+        for resp in self.iter_responses("/", origin="http://app1.example.com"):
+            self.assertEqual(resp.headers.get(ACL_ORIGIN), "http://app1.example.com")
+
+    def test_extension_callable_denied(self):
+        """Extension with callable origins should reject non-matching origins."""
+        for resp in self.iter_responses("/", origin="http://evil.com"):
+            self.assertIsNone(resp.headers.get(ACL_ORIGIN))


### PR DESCRIPTION
Allow the `origins` parameter to be a callable that receives the request origin and returns allowed origins at runtime. This enables dynamic origin validation against databases or external services without restarting the application. 

My use case is [Canaille](https://canaille.readthedocs.io), an identity server. I would like to authorize the domain of new OIDC clients dynamically when they are created.

fixes #281
supersedes #268 and #282