### PR TITLE
Add SECURITY.md with disclosure policy (#341)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Flask-CORS, please report it
+privately so it can be patched before public disclosure.
+
+**Preferred channel: GitHub Security Advisories.**
+
+Open a private advisory at:
+<https://github.com/corydolphin/flask-cors/security/advisories/new>
+
+This route is private to maintainers and lets us coordinate a fix and a
+CVE assignment before any public discussion.
+
+Please include, when possible:
+
+- The Flask-CORS version affected (`pip show Flask-Cors`).
+- A minimal Flask app reproducing the issue.
+- The expected vs. observed behaviour, including any HTTP exchange.
+- Your assessment of impact (e.g. origin bypass, header injection,
+  privilege escalation).
+
+If you cannot use GitHub Security Advisories, please email
+`corydolphin@gmail.com` with the subject line `flask-cors security`.
+
+## Supported Versions
+
+Only the latest minor release line receives security fixes. Older
+versions may be patched on a best-effort basis.
+
+## Disclosure
+
+Once a fix is available we will publish a GitHub Security Advisory,
+request a CVE if appropriate, and credit the reporter (unless asked
+otherwise).
+
+## Past advisories
+
+Past CVEs and fixes are listed under the project's
+[Security tab](https://github.com/corydolphin/flask-cors/security)
+and in the
+[CHANGELOG](https://github.com/corydolphin/flask-cors/blob/main/CHANGELOG.md).


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` so security researchers have a documented, private
channel for vulnerability disclosure instead of opening public issues.

Fixes #341.

## Context

#341 was opened in 2022 by a Huntr-affiliated researcher asking for a
`SECURITY.md` with a contact address. Since then several CVEs have been
filed against flask-cors via the public issue tracker (e.g. the threads
that became CVE-2024-6221, CVE-2024-6839, CVE-2024-6844, CVE-2024-6866),
which is exactly the situation a security policy is supposed to avoid.
GitHub also surfaces a missing-`SECURITY.md` warning on the repo
[Security tab](https://github.com/corydolphin/flask-cors/security/policy).

## Changes

- `SECURITY.md` (new): minimal policy pointing reporters at GitHub
  Security Advisories (private, maintainer-only) with `corydolphin@gmail.com`
  as fallback. Includes a "what to include" checklist (version, repro,
  expected vs observed, impact) and a brief disclosure / supported-versions
  section.

No source changes. No behavior changes. Only a docs/policy file at the
repo root, which is the location GitHub looks for when surfacing the
security policy link on advisories.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
mkdir -p /tmp/repro && cd /tmp/repro && rm -rf flask-cors
git clone https://github.com/corydolphin/flask-cors.git
cd flask-cors

# --- BEFORE: origin/main, no SECURITY.md ---
git checkout origin/main
ls SECURITY.md .github/SECURITY.md 2>&1 | head -2
# Expected: "ls: cannot access 'SECURITY.md': No such file or directory"
#           "ls: cannot access '.github/SECURITY.md': No such file or directory"

# --- AFTER: this branch, SECURITY.md present ---
git fetch https://github.com/jbbqqf/flask-cors.git fix/341-add-security-md
git checkout FETCH_HEAD
ls SECURITY.md
head -3 SECURITY.md
# Expected: "SECURITY.md"
#           "# Security Policy"
#           ""
#           "## Reporting a Vulnerability"
```

## What I ran locally

```bash
$ .venv/bin/python -m pytest -q
.............................................................................
............................. 95 passed, 1 skipped, 1 warning in 0.51s
```

No tests touch this file; the suite was run as a sanity check that the
new file doesn't break the existing checks.

## Edge cases

| # | Scenario | Expected | Verified by |
|---|---|---|---|
| 1 | GitHub repo Security tab discoverability | Repo Security tab points at `SECURITY.md` at root | GitHub renders root `SECURITY.md` on the [Security policy page](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) |
| 2 | Email fallback for reporters without GitHub | `corydolphin@gmail.com` listed as fallback | Pulled from `pyproject.toml` `authors` field — already public |
| 3 | Versions covered | "Only the latest minor release line receives security fixes" | Matches the observed pattern of fixes shipping in 6.x only |

## Risk / blast radius

Pure docs / policy file. No imports, no public API change, no test
changes. Safe to merge independently from any code change.

## Notes for the maintainer

- I deliberately set GitHub Security Advisories as the **preferred**
  channel because it gives you a private workspace, CVE request flow,
  and a ready-to-publish advisory. Email is fallback.
- The contact address used is `corydolphin@gmail.com` from
  `pyproject.toml`'s `authors` — happy to swap to a dedicated alias if
  you'd prefer.
- I avoided promising disclosure timelines (e.g. "fixed within 90 days")
  since this is a volunteer-maintained project; the text just says
  best-effort.

---

*PR drafted with assistance from Claude Code (Anthropic). The change
was reviewed manually against flask-cors's source. The BEFORE/AFTER
reproducer above is the one I used during development; reviewers can
paste it verbatim.*
