### PR TITLE
Add PyPI publish attestations to releases

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv build
 
       - name: Publish package
-        run: uv publish --trusted-publishing always
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   deploy-docs:
     needs: publish


### PR DESCRIPTION
### Summary

Hi! This switches the release upload step from `uv publish` to `pypa/gh-action-pypi-publish@v1.14.0`.

`flask-cors` already publishes from GitHub Actions using PyPI Trusted Publishing/OIDC. Using the official PyPA publish action keeps that flow, but also generates and uploads PyPI publish attestations by default, so this should not require any new PyPI-side configuration or secrets.

Those attestations bind each uploaded distribution to the GitHub Actions workflow that published it, giving PyPI and downstream users stronger provenance for the release artifacts.

### Possible follow-ups

I kept this PR intentionally small for reviewability, but noticed a few related release-hardening opportunities while looking at the workflow:

- Pin GitHub Actions to full commit SHAs.
- Avoid cache use in release artifact builds.
- Split build and publish into separate jobs, so `id-token: write` is only available in the final upload job.

### Testing

Not run; workflow-only change.