### PR TITLE
Improve CI/CD security with least privilege and build separation

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: true

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -4,38 +4,74 @@ on:
   release:
     types: [published]
 
+# Least privilege by default; each job opts in to exactly what it needs.
+permissions: {}
+
 jobs:
-  publish:
+  # Build the distributions WITHOUT id-token access and WITHOUT a restored
+  # cache, so no third-party code in the build path can mint a PyPI token or
+  # poison the release artifacts.
+  build:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
-      id-token: write # this permission is mandatory for trusted publishing
+      contents: read
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Fetch the full history and all tags so that setuptools-scm can
           # derive the version from the released git tag.
           fetch-depth: 0
 
-      - name: Set up the environment
-        uses: ./.github/actions/setup-python-env
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: "0.6.2"
+          enable-cache: false
 
       - name: Build package
         run: uv build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+
+  # Minimal job that holds id-token: write. It only downloads the prebuilt
+  # distributions and publishes them, so the OIDC token is exposed to as
+  # little code as possible. `environment: release` lets you gate this step
+  # behind a required reviewer and restrict it to tags in repo settings.
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write # mandatory for trusted publishing
+    needs: [build]
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Show built artifacts
         run: ls -l dist/
 
       - name: Publish package
-        run: uv publish --trusted-publishing always
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true
+          print-hash: true
 
   deploy-docs:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh-deploy pushes the built docs to the gh-pages branch
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env


### PR DESCRIPTION
## Summary
Enhance the security posture of the release workflow by implementing least privilege principles and separating the build and publish steps to minimize exposure of the PyPI publishing token.

## Key Changes

- **Least Privilege Permissions**: Added default `permissions: {}` at the workflow level with explicit opt-in for each job, ensuring jobs only have access to the minimum required permissions.

- **Build/Publish Separation**: Split the `publish` job into two distinct jobs:
  - `build`: Builds distributions without `id-token` access or cache restoration, preventing third-party code from minting PyPI tokens or poisoning artifacts
  - `publish`: Minimal job that only downloads pre-built distributions and publishes them, limiting OIDC token exposure to the absolute minimum code path