### PR TITLE
Add OpenSSF Scorecard security analysis workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,68 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          sarif_file: results.sarif

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Flask-CORS
 ==========
 
 |Build Status| |Latest Version| |Supported Python versions|
-|License|
+|License| |OpenSSF Scorecard|
 
 A Flask extension for handling Cross Origin Resource Sharing (CORS), making cross-origin AJAX possible.
 
@@ -118,3 +118,5 @@ This Flask extension is based upon the `Decorator for the HTTP Access Control <h
    :target: https://img.shields.io/pypi/pyversions/Flask-Cors.svg
 .. |License| image:: http://img.shields.io/:license-mit-blue.svg
    :target: https://pypi.python.org/pypi/Flask-Cors/
+.. |OpenSSF Scorecard| image:: https://api.scorecard.dev/projects/github.com/corydolphin/flask-cors/badge
+   :target: https://scorecard.dev/viewer/?uri=github.com/corydolphin/flask-cors


### PR DESCRIPTION
## Summary
This PR adds OpenSSF Scorecard integration to the repository for continuous supply-chain security monitoring and analysis.

## Key Changes
- **Added GitHub Actions workflow** (`.github/workflows/scorecard.yml`):
  - Runs Scorecard analysis on push to main branch and weekly on Tuesdays
  - Uploads results to GitHub's code scanning dashboard
  - Publishes results to OpenSSF REST API for public visibility
  - Stores SARIF artifacts for 5 days
  - Uses pinned action versions for security

- **Updated README.rst**:
  - Added OpenSSF Scorecard badge to the status badges section
  - Badge links to the project's Scorecard report on scorecard.dev

## Implementation Details
- Workflow uses minimal permissions (read-only by default) with specific elevated permissions only for necessary steps
- Scorecard action configured to output SARIF format for integration with GitHub's code scanning
- Results are published to OpenSSF's public API, allowing the repository to display the Scorecard badge
- All GitHub Actions use specific commit SHAs for reproducibility and security

https://claude.ai/code/session_01XyjhGhe5sfV6BQKgjC3SiQ