### PR TITLE
Restore Blueprint support in CORS type signatures (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Fix `mypy --strict` rejecting `CORS(blueprint)` / `init_app(blueprint)`. The `app` parameter is now typed as `Flask | Blueprint | None`, restoring Blueprint support broken in 6.0.4 ([#410](https://github.com/corydolphin/flask-cors/issues/410)). A type-checking regression test guards this going forward.
 * Add full type annotations and a `py.typed` marker. The package now passes `mypy --strict`, checked in CI.
 * Type the keyword arguments to `CORS`, `init_app`, and `cross_origin` so invalid options are caught by type checkers.
 * Resolve options into a frozen internal dataclass instead of a plain dict.

--- a/examples/app_based_example.py
+++ b/examples/app_based_example.py
@@ -7,15 +7,20 @@ to add cross origin support to your flask app!
 :copyright: (c) 2016 by Cory Dolphin.
 :license:   MIT/X11, see LICENSE for more details.
 """
-from flask import Flask, jsonify
+from __future__ import annotations
+
 import logging
+
+from flask import Flask, Response, jsonify
+
 try:
     from flask_cors import CORS  # The typical way to import flask-cors
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
+    import sys
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    os.sys.path.insert(0, parentdir)
+    sys.path.insert(0, parentdir)
 
     from flask_cors import CORS
 
@@ -33,7 +38,7 @@ CORS(app, resources=r'/api/*')
 
 
 @app.route("/")
-def helloWorld():
+def helloWorld() -> str:
     """
         Since the path '/' does not match the regular expression r'/api/*',
         this route does not have CORS headers set.
@@ -49,7 +54,7 @@ def helloWorld():
 '''
 
 @app.route("/api/v1/users/")
-def list_users():
+def list_users() -> Response:
     """
         Since the path matches the regular expression r'/api/*', this resource
         automatically has CORS headers set. The expected result is as follows:
@@ -73,7 +78,7 @@ def list_users():
 
 
 @app.route("/api/v1/users/create", methods=['POST'])
-def create_user():
+def create_user() -> Response:
     """
         Since the path matches the regular expression r'/api/*', this resource
         automatically has CORS headers set.
@@ -116,7 +121,7 @@ def create_user():
     return jsonify(success=True)
 
 @app.route("/api/exception")
-def get_exception():
+def get_exception() -> str:
     """
         Since the path matches the regular expression r'/api/*', this resource
         automatically has CORS headers set.
@@ -141,7 +146,7 @@ def get_exception():
     raise Exception("example")
 
 @app.errorhandler(500)
-def server_error(e):
+def server_error(e: Exception) -> tuple[str, int]:
     logging.exception('An error occurred during a request. %s', e)
     return "An internal error occurred", 500
 

--- a/examples/blueprints_based_example.py
+++ b/examples/blueprints_based_example.py
@@ -7,15 +7,20 @@ to add cross origin support to your flask app!
 :copyright: (c) 2016 by Cory Dolphin.
 :license:   MIT/X11, see LICENSE for more details.
 """
-from flask import Flask, jsonify, Blueprint
+from __future__ import annotations
+
 import logging
+
+from flask import Blueprint, Flask, Response, jsonify
+
 try:
     from flask_cors import CORS  # The typical way to import flask-cors
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
+    import sys
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    os.sys.path.insert(0, parentdir)
+    sys.path.insert(0, parentdir)
 
     from flask_cors import CORS
 
@@ -25,7 +30,7 @@ api_v1 = Blueprint('API_v1', __name__)
 CORS(api_v1) # enable CORS on the API_v1 blue print
 
 @api_v1.route("/api/v1/users/")
-def list_users():
+def list_users() -> Response:
     '''
         Since the path matches the regular expression r'/api/*', this resource
         automatically has CORS headers set. The expected result is as follows:
@@ -49,7 +54,7 @@ def list_users():
 
 
 @api_v1.route("/api/v1/users/create", methods=['POST'])
-def create_user():
+def create_user() -> Response:
     '''
         Since the path matches the regular expression r'/api/*', this resource
         automatically has CORS headers set.
@@ -94,7 +99,7 @@ def create_user():
 public_routes = Blueprint('public', __name__)
 
 @public_routes.route("/")
-def helloWorld():
+def helloWorld() -> str:
     '''
         Since the path '/' does not match the regular expression r'/api/*',
         this route does not have CORS headers set.

--- a/examples/view_based_example.py
+++ b/examples/view_based_example.py
@@ -7,16 +7,21 @@ to add cross origin support to your flask app!
 :copyright: (c) 2016 by Cory Dolphin.
 :license:   MIT/X11, see LICENSE for more details.
 """
-from flask import Flask, jsonify
+from __future__ import annotations
+
 import logging
+
+from flask import Flask, Response, jsonify
+
 try:
     # The typical way to import flask-cors
     from flask_cors import cross_origin
 except ImportError:
     # Path hack allows examples to be run without installation.
     import os
+    import sys
     parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    os.sys.path.insert(0, parentdir)
+    sys.path.insert(0, parentdir)
 
     from flask_cors import cross_origin
 
@@ -26,7 +31,7 @@ logging.basicConfig(level=logging.INFO)
 
 @app.route("/", methods=['GET'])
 @cross_origin()
-def helloWorld():
+def helloWorld() -> str:
     '''
         This view has CORS enabled for all domains, representing the simplest
         configuration of view-based decoration. The expected result is as
@@ -54,7 +59,7 @@ on <a href="https://github.com/corydolphin/flask-cors">Github</a>'''
 
 @app.route("/api/v1/users/create", methods=['GET', 'POST'])
 @cross_origin(allow_headers=['Content-Type'])
-def cross_origin_json_post():
+def cross_origin_json_post() -> Response:
     '''
         This view has CORS enabled for all domains, and allows browsers
         to send the Content-Type header, allowing cross domain AJAX POST

--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, TypedDict, Union, cast
 
-from flask import Flask, Response, current_app, request
+from flask import Blueprint, Flask, Response, current_app, request
 from werkzeug.datastructures import Headers, MultiDict
 
 LOG = logging.getLogger(__name__)
@@ -425,7 +425,7 @@ def try_match_pattern(value: Any, pattern: ResourcePattern, caseSensitive: bool 
     return v == p if caseSensitive else v.casefold() == p.casefold()
 
 
-def merge_options(appInstance: Flask | None, *dicts: Mapping[str, Any]) -> dict[str, Any]:
+def merge_options(appInstance: Flask | Blueprint | None, *dicts: Mapping[str, Any]) -> dict[str, Any]:
     """
     Merge the DEFAULT_OPTIONS, the app's configuration-specified options and any
     dictionaries passed into a single raw options mapping. The last specified
@@ -438,12 +438,12 @@ def merge_options(appInstance: Flask | None, *dicts: Mapping[str, Any]) -> dict[
     return options
 
 
-def get_cors_options(appInstance: Flask | None, *dicts: Mapping[str, Any]) -> _ComputedCorsOptions:
+def get_cors_options(appInstance: Flask | Blueprint | None, *dicts: Mapping[str, Any]) -> _ComputedCorsOptions:
     """Compute the resolved CORS options for an application (see merge_options)."""
     return serialize_options(merge_options(appInstance, *dicts))
 
 
-def get_app_kwarg_dict(appInstance: Flask | None = None) -> dict[str, Any]:
+def get_app_kwarg_dict(appInstance: Flask | Blueprint | None = None) -> dict[str, Any]:
     """Returns the dictionary of CORS specific app configurations."""
     app = appInstance or current_app
 

--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
-from flask import Flask, Response, request
+from flask import Blueprint, Flask, Response, request
 
 from .core import (
     ACL_ORIGIN,
@@ -160,12 +160,12 @@ class CORS:
     :type allow_private_network: bool
     """
 
-    def __init__(self, app: Flask | None = None, **kwargs: Unpack[CorsOptionsInput]) -> None:
+    def __init__(self, app: Flask | Blueprint | None = None, **kwargs: Unpack[CorsOptionsInput]) -> None:
         self._options = kwargs
         if app is not None:
             self.init_app(app, **kwargs)
 
-    def init_app(self, app: Flask, **kwargs: Unpack[CorsOptionsInput]) -> None:
+    def init_app(self, app: Flask | Blueprint, **kwargs: Unpack[CorsOptionsInput]) -> None:
         # The resources and options may be specified in the App Config, the CORS constructor
         # or the kwargs to the call to init_app.
         merged = merge_options(app, self._options, kwargs)
@@ -193,23 +193,22 @@ class CORS:
         cors_after_request = make_after_request_function(resolved_resources)
         app.after_request(cors_after_request)
 
-        # Wrap exception handlers with cross_origin
-        # These error handlers will still respect the behavior of the route
-        if options.intercept_exceptions:
+        # Wrap exception handlers with cross_origin so error responses also
+        # receive CORS headers. Blueprints have no ``handle_exception`` /
+        # ``make_response``, so the ``hasattr`` guard skips them; the ``Any``
+        # alias lets us read and reassign those Flask-only methods without
+        # tripping mypy's attr-defined / method-assign checks for ``Blueprint``.
+        if options.intercept_exceptions and hasattr(app, "handle_exception"):
+            app_any: Any = app
 
             def _after_request_decorator(f: Callable[..., Any]) -> Callable[..., Response]:
                 def wrapped_function(*args: Any, **kwargs: Any) -> Response:
-                    return cors_after_request(app.make_response(f(*args, **kwargs)))
+                    return cors_after_request(app_any.make_response(f(*args, **kwargs)))
 
                 return wrapped_function
 
-            if hasattr(app, "handle_exception"):
-                # Wrap Flask's exception handlers so error responses also
-                # receive CORS headers. An ``Any`` alias lets us reassign the
-                # bound methods without tripping mypy's method-assign check.
-                app_any: Any = app
-                app_any.handle_exception = _after_request_decorator(app.handle_exception)
-                app_any.handle_user_exception = _after_request_decorator(app.handle_user_exception)
+            app_any.handle_exception = _after_request_decorator(app_any.handle_exception)
+            app_any.handle_user_exception = _after_request_decorator(app_any.handle_user_exception)
 
 
 def make_after_request_function(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ testpaths = ["tests"]
 DEP002 = ["typing_extensions"]
 
 [tool.mypy]
-files = ["flask_cors"]
+# ``tests/typecheck`` holds static-typing regression tests (e.g. Blueprint
+# support, see issue #410); it is type-checked alongside the package, as are the
+# ``examples``, so the public signatures cannot silently regress.
+files = ["flask_cors", "tests/typecheck", "examples"]
 python_version = "3.9"
 strict = true
 warn_redundant_casts = true

--- a/tests/extension/test_blueprint.py
+++ b/tests/extension/test_blueprint.py
@@ -1,0 +1,72 @@
+"""
+test_blueprint
+~~~~~~~~~~~~~~
+Flask-CORS supports applying CORS configuration directly to a Flask
+Blueprint, in addition to a whole application. Blueprints do not expose a
+``config`` attribute or the ``handle_exception`` hooks, so these tests guard
+that the extension keeps working when handed one.
+
+:copyright: (c) 2016 by Cory Dolphin.
+:license: MIT, see LICENSE for more details.
+"""
+
+from flask import Blueprint, Flask
+
+from flask_cors import *
+from flask_cors.core import *
+
+from ..base_test import FlaskCorsTestCase
+
+
+class BlueprintExtensionTestCase(FlaskCorsTestCase):
+    def setUp(self):
+        self.bp = Blueprint("blueprint", __name__)
+        CORS(self.bp, resources={r"/api/*": {"origins": "http://foo.com"}})
+
+        @self.bp.route("/api/v1/ping")
+        def ping():
+            return "pong"
+
+        @self.bp.route("/no_cors")
+        def no_cors():
+            return "no cors here"
+
+        self.app = Flask(__name__)
+        self.app.register_blueprint(self.bp)
+
+    def test_blueprint_resource_has_cors(self):
+        """Routes registered on a CORS-enabled blueprint and matching the
+        configured resource should receive CORS headers.
+        """
+        resp = self.get("/api/v1/ping", origin="http://foo.com")
+        self.assertEqual(resp.headers.get(ACL_ORIGIN), "http://foo.com")
+
+    def test_blueprint_non_matching_route_has_no_cors(self):
+        """Routes that do not match the configured resource should not have
+        CORS headers set.
+        """
+        resp = self.get("/no_cors", origin="http://foo.com")
+        self.assertFalse(ACL_ORIGIN in resp.headers)
+
+    def test_blueprint_init_app(self):
+        """Blueprints should also be configurable via ``init_app``."""
+        bp = Blueprint("blueprint_init", __name__)
+
+        @bp.route("/api/v2/ping")
+        def ping_v2():
+            return "pong"
+
+        cors = CORS(resources={r"/api/*": {"origins": "http://bar.com"}})
+        cors.init_app(bp)
+
+        self.app = Flask(__name__)
+        self.app.register_blueprint(bp)
+
+        resp = self.get("/api/v2/ping", origin="http://bar.com")
+        self.assertEqual(resp.headers.get(ACL_ORIGIN), "http://bar.com")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/typecheck/test_blueprint_typing.py
+++ b/tests/typecheck/test_blueprint_typing.py
@@ -1,0 +1,33 @@
+"""
+test_blueprint_typing
+~~~~~~~~~~~~~~~~~~~~~~
+Static-typing regression test: ``CORS``/``init_app`` must keep accepting a
+``Blueprint`` as well as a ``Flask`` app. ``tests/typecheck`` is checked by
+mypy (strict) in CI, so narrowing the signature back to ``Flask`` only --
+as in https://github.com/corydolphin/flask-cors/issues/410 -- fails here.
+
+These functions exist only to be analyzed statically; they are not run.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, Flask
+
+from flask_cors import CORS
+
+
+def supports_flask_app() -> None:
+    app = Flask(__name__)
+    CORS(app, resources={r"/api/*": {"origins": "http://example.com"}})
+    CORS().init_app(app)
+
+
+def supports_blueprint() -> None:
+    bp = Blueprint("api", __name__)
+    # Must type-check: a Blueprint is a valid target for CORS.
+    CORS(bp, resources={r"/api/*": {"origins": "http://example.com"}})
+    CORS().init_app(bp)
+
+
+def supports_no_app() -> None:
+    CORS()


### PR DESCRIPTION
## Summary

Fixes #410.

The strict typing added in #409 (released in 6.0.4) narrowed the `app` parameter of `CORS.__init__`/`init_app` to `Flask | None`. Flask-CORS supports applying CORS directly to a `Blueprint` at runtime — `get_app_kwarg_dict` already guards for the missing `config` attribute, and the exception-handler wrapping is guarded by `hasattr(app, "handle_exception")` — so passing a Blueprint still worked, but it began failing `mypy --strict` for downstream users:

```
error: Argument 1 to "CORS" has incompatible type "Blueprint"; expected "Flask | None"  [arg-type]
```

This realigns the type annotation with the behavior the runtime guards already implement.

## Changes

- **Widen the accepted type** to `Flask | Blueprint | None` on `CORS.__init__`, `init_app`, and the internal `merge_options` / `get_cors_options` / `get_app_kwarg_dict` helpers.
- **Route the Flask-only `make_response` / `handle_exception` accesses through an `Any` alias**, gated by the existing `hasattr` guard, so the wider union type-checks cleanly (no behavior change — the block already only ran for full apps).
- **Add runtime tests** exercising CORS on a Blueprint via both the constructor and `init_app` (there was previously no Blueprint test coverage).
- **Add a type-checking regression test** (`tests/typecheck/`) included in the mypy `files` list, so a future narrowing of the signature fails CI. Verified: reverting the signature makes mypy fail on exactly that test.
- **Type-check the `examples/` directory** under strict mypy as well, fixing the non-exported `os.sys` path hack and adding view return annotations.

## Verification

- `mypy` — clean (9 source files)
- `pytest` — 98 passed, 1 skipped
- `ruff` — clean

## Follow-up

6.0.4 isn't broken at runtime (it only fails strict typing for Blueprint users), so the suggested path is to release this as **6.0.5** and then **yank 6.0.4** on PyPI with a reason pointing at 6.0.5 (yank keeps it installable for anyone already pinned, while steering new installs past it).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KfTZRSScWS5xFuqzCayPKF)_