### PR TITLE
Allow the QUERY method (RFC 10008) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Allow the `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)) by default. `QUERY` is not CORS-safelisted, so cross-origin use is preflighted; because it was missing from `ALL_METHODS`, flask-cors omitted the `Access-Control-Allow-Methods` header entirely and the browser blocked the request.
 * Fix `mypy --strict` rejecting `CORS(blueprint)` / `init_app(blueprint)`. The `app` parameter is now typed as `Flask | Blueprint | None`, restoring Blueprint support broken in 6.0.4 ([#410](https://github.com/corydolphin/flask-cors/issues/410)). A type-checking regression test guards this going forward.
 * Add full type annotations and a `py.typed` marker. The package now passes `mypy --strict`, checked in CI.
 * Type the keyword arguments to `CORS`, `init_app`, and `cross_origin` so invalid options are caught by type checkers.

--- a/flask_cors/core.py
+++ b/flask_cors/core.py
@@ -115,7 +115,9 @@ ACL_REQUEST_METHOD = "Access-Control-Request-Method"
 ACL_REQUEST_HEADERS = "Access-Control-Request-Headers"
 ACL_REQUEST_HEADER_PRIVATE_NETWORK = "Access-Control-Request-Private-Network"
 
-ALL_METHODS = ["GET", "HEAD", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"]
+# QUERY is the safe, idempotent method with a request body defined by RFC 10008.
+# Like PUT/PATCH/DELETE it is not CORS-safelisted, so cross-origin use is preflighted.
+ALL_METHODS = ["GET", "HEAD", "POST", "OPTIONS", "PUT", "PATCH", "DELETE", "QUERY"]
 CONFIG_OPTIONS = [
     "CORS_ORIGINS",
     "CORS_METHODS",

--- a/flask_cors/decorator.py
+++ b/flask_cors/decorator.py
@@ -38,7 +38,7 @@ def cross_origin(*args: Any, **kwargs: Unpack[CrossOriginOptionsInput]) -> Calla
         The method or list of methods which the allowed origins are allowed to
         access for non-simple requests.
 
-        Default : [GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE]
+        Default : [GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE, QUERY]
     :type methods: list or string
 
     :param expose_headers:

--- a/flask_cors/extension.py
+++ b/flask_cors/extension.py
@@ -87,7 +87,7 @@ class CORS:
         The method or list of methods which the allowed origins are allowed to
         access for non-simple requests.
 
-        Default : [GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE]
+        Default : [GET, HEAD, POST, OPTIONS, PUT, PATCH, DELETE, QUERY]
     :type methods: list or string
 
     :param expose_headers:

--- a/tests/decorator/test_methods.py
+++ b/tests/decorator/test_methods.py
@@ -41,6 +41,15 @@ class MethodsCase(FlaskCorsTestCase):
         for method in ALL_METHODS:
             self.assertTrue(method in res.headers.get(ACL_METHODS))
 
+    def test_query_method_allowed_by_default(self):
+        ''' QUERY (RFC 10008) is not CORS-safelisted, so a cross-origin QUERY
+            is preflighted. It must be allowed by default, like the other
+            non-safelisted methods.
+        '''
+        res = self.preflight('/defaults', 'QUERY', origin='www.example.com')
+        self.assertIsNotNone(res.headers.get(ACL_METHODS))
+        self.assertTrue('QUERY' in res.headers.get(ACL_METHODS))
+
     def test_methods_defined(self):
         ''' If the methods parameter is defined, it should override the default
             methods defined by the user.


### PR DESCRIPTION
`QUERY` is the safe, idempotent method with a request body standardized in [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) (June 2026). It is not CORS-safelisted, so cross-origin use is preflighted, exactly like `PUT`, `PATCH` and `DELETE`.

Because `QUERY` was missing from `ALL_METHODS`, a preflight carrying `Access-Control-Request-Method: QUERY` fails the membership check in `get_cors_headers` (`flask_cors/core.py:330`), which drops the **entire** `Access-Control-Allow-Methods` header rather than emitting a list without `QUERY`. The browser then blocks the request, and the response gives no hint as to why.

Measured against flask-cors 6.0.5, same app, two preflights:

```
# CORS(app), Access-Control-Request-Method: QUERY
HTTP/1.0 200 OK
Access-Control-Allow-Origin: http://example.com
                                    <-- no Access-Control-Allow-Methods at all

# CORS(app), Access-Control-Request-Method: POST   (control)
HTTP/1.0 200 OK
Access-Control-Allow-Origin: http://example.com
Access-Control-Allow-Methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
```

Flask already routes `methods=["QUERY"]` and parses the body via `request.get_json()`, so the server side works today; only the CORS default was out of date. Browsers need no update either — `QUERY` is neither a forbidden nor a normalized method in the Fetch standard, so `fetch(url, {method: 'QUERY', body})` and `XMLHttpRequest` already send it in current Chromium and Firefox. The CORS default is the remaining blocker for cross-origin use.

## Changes

- `flask_cors/core.py` — add `QUERY` to `ALL_METHODS`
- `flask_cors/decorator.py`, `flask_cors/extension.py` — update the documented default in the `methods` docstrings
- `tests/decorator/test_methods.py` — regression test asserting a default-config `QUERY` preflight gets `Access-Control-Allow-Methods`
- `CHANGELOG.md` — entry under `Unreleased`

## Checks

- `make test` — 99 passed, 1 skipped
- `make check` — mypy clean, deptry clean, lock file consistent
- New test verified to fail without the `core.py` change (`AssertionError: unexpectedly None`)

## Notes

Users on released versions can work around this today with an explicit list:

```python
CORS(app, methods=["GET", "HEAD", "POST", "OPTIONS", "PUT", "PATCH", "DELETE", "QUERY"])
```

Two unrelated things noticed while following CONTRIBUTING, not addressed here:

- The lint step in `make check` is a no-op — the pre-commit line in the `Makefile` is commented out (`# @uv run pre-commit run -a`).
- Running pre-commit manually, the `ruff` hook fails on this repo's own `pyproject.toml` with `Unknown rule selector: TC`; the ruff version pinned in `.pre-commit-config.yaml` predates that selector.

Happy to adjust naming, test placement, or drop the code comment if you'd rather keep the constant bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
